### PR TITLE
Fixes issues associated with kickstart and patch files

### DIFF
--- a/kickstart-files/ks-atomic.cfg
+++ b/kickstart-files/ks-atomic.cfg
@@ -13,7 +13,7 @@ keyboard --vckeymap=us --xlayouts='us'
 # Root password
 rootpw --iscrypted $6$8z2.xKRx6YdOvRDP$BwfVHPhTed9HtUA3oBJM.Y0tVppkzZLloOj5TkKojWgKsG4BJJaiM/bbQioqxUbuIaSKTMQ4aOvJG2FB9oVBS.
 # Network information
-network --device=enp0s25 --bootproto=static --gateway=172.17.16.1 --ip=172.17.16.11 --nameserver=172.17.10.22 --netmask=255.255.255.0 --onboot=on --ipv6=auto --hostname=localhost.localdomain
+network --bootproto=dhcp --onboot=on --hostname=localhost.localdomain
 # System authorization information
 auth --enableshadow --passalgo=sha512
 # System timezone

--- a/kickstart-files/ks-isolinux-packer.cfg
+++ b/kickstart-files/ks-isolinux-packer.cfg
@@ -17,8 +17,7 @@ keyboard --vckeymap=us --xlayouts='us'
 lang en_US.UTF-8
 
 # Network information
-network --bootproto=dhcp --ipv6=auto --activate
-network --hostname=localhost.localdomain
+network --bootproto=dhcp --onboot=on --hostname=localhost.localdomain
 
 # Root password
 rootpw changeme
@@ -54,7 +53,11 @@ echo "packer"|passwd --stdin packer
 echo "packer        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/packer
 chmod 0440 /etc/sudoers.d/packer
 
-/usr/sbin/subscription-manager register --username username --password password --autosubscribe
+# register the node.  Note that you should replace the following variables in this
+# command with valid RHN credentials:
+#     RHN_USERNAME with the username of an account with a valid subscription
+#     RHN_PASSWORD with the password for that account
+/usr/sbin/subscription-manager register --username RHN_USERNAME --password RHN_PASSWORD --autosubscribe
 /usr/sbin/subscription-manager repos --disable=*
 /usr/sbin/subscription-manager repos --enable=rhel-7-server-optional-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-rpms
 

--- a/kickstart-files/ks-isolinux.cfg
+++ b/kickstart-files/ks-isolinux.cfg
@@ -1,8 +1,3 @@
-# Replace the following variables with valid credentials in the post section of this file
-# <rhn_username> with valid Red Hat user with valid subscription
-# <rhn_password> with the password for that account
-# git_username:git_password with a valid git user with access to the csc/kragle repository
-
 #version=RHEL7
 
 # install a fresh system
@@ -38,8 +33,6 @@ volgroup rhel --pesize=4096 pv.343
 logvol swap  --fstype="swap" --size=8000 --name=swap --vgname=rhel
 logvol /home  --fstype="xfs" --size=51200 --name=home --vgname=rhel
 logvol /  --fstype="xfs" --size=1 --name=root --vgname=rhel --grow
-# poweroff automatically at the end of the installation process
-poweroff
 # define packages to install
 %packages
 @core
@@ -48,17 +41,52 @@ kexec-tools
 # add 'kdump' add-on to the install
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 %end
-
 # install epel-release, ansible and git and clone the kragle source repository
 %post --log=/root/ks-post.log
+/bin/sed -i 's/^ONBOOT=no$/ONBOOT=yes/' /etc/sysconfig/network-scripts/ifcfg-e*
+cat > /tmp/postinstall.sh << EOF
+#!/bin/bash
 
-/usr/sbin/subscription-manager register --username <rhn_username> --password <rhn_password> --autosubscribe
+# restart the network
+systemctl restart network
+# Wait for network to come up when using NetworkManager.
+if service NetworkManager status >/dev/null 2>&1 && type -P nm-online; then
+    nm-online -q --timeout=10 || nm-online -q -x --timeout=30
+    [ "$?" -eq 0 ] || exit 1
+fi
+# show the network config
+ip addr
+# register the node.  Note that you should replace the following variables in this
+# command with valid RHN credentials:
+#     RHN_USERNAME with the username of an account with a valid subscription
+#     RHN_PASSWORD with the password for that account
+/usr/sbin/subscription-manager register --username RHN_USERNAME --password RHN_PASSWORD --autosubscribe
+# enable the rhel7-server-extras repository
 /usr/sbin/subscription-manager repos --enable=rhel-7-server-extras-rpms
-
+# install a few packages
 yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 yum -y install git ansible
-
-git clone https://git_username:git_password@github.com/csc/kragle
-
-ansible-playbook -i localhost, ansible/kragle/main.yml
+# setup localhost so that SSH will always succeed (without asking to verifyt he key)
+cat > ~/.ssh/config << EOF2
+Host localhost
+    Hostname localhost
+    StrictHostKeyChecking no
+EOF2
+chmod 400 ~/.ssh/config
+# clone the kragle repository
+cd /tmp
+git clone https://github.com/csc/kragle
+# run the main ansible playbook from the kragle project
+cd kragle
+ansible-playbook -i ansible/inventory/hosts.ini ansible/main.yml
+# and cleanup
+rm -f ~/.ssh/config
+sed -i --follow-symlinks '/postinstall/d' /etc/rc.local
+# and poweroff the system
+poweroff
+EOF
+echo bash /tmp/postinstall.sh >> /etc/rc.local
+chmod +x /tmp/postinstall.sh
+# This line needs to be added otherwise rc.local will not execute on boot
+chmod +x /etc/rc.d/rc.local
 %end

--- a/kickstart-files/ks-uefi.cfg
+++ b/kickstart-files/ks-uefi.cfg
@@ -1,8 +1,3 @@
-# Replace the following variables with valid credentials in the post section of this file
-# <rhn_username> with valid Red Hat user with valid subscription
-# <rhn_password> with the password for that account
-# git_username:git_password with a valid git user with access to the csc/kragle repository
-
 #version=RHEL7
 
 # install a fresh system
@@ -18,7 +13,7 @@ keyboard --vckeymap=us --xlayouts='us'
 # Root password
 rootpw --iscrypted $6$8z2.xKRx6YdOvRDP$BwfVHPhTed9HtUA3oBJM.Y0tVppkzZLloOj5TkKojWgKsG4BJJaiM/bbQioqxUbuIaSKTMQ4aOvJG2FB9oVBS.
 # Network information
-network --device=enp0s25 --bootproto=static --gateway=172.17.16.1 --ip=172.17.16.10 --nameserver=172.17.10.22 --netmask=255.255.255.0 --onboot=on --ipv6=auto --hostname=localhost.localdomain
+network --hostname=localhost.localdomain
 # System authorization information
 auth --enableshadow --passalgo=sha512
 # System timezone
@@ -39,8 +34,6 @@ volgroup rhel --pesize=4096 pv.343
 logvol swap  --fstype="swap" --size=8000 --name=swap --vgname=rhel
 logvol /home  --fstype="xfs" --size=51200 --name=home --vgname=rhel
 logvol /  --fstype="xfs" --size=1 --name=root --vgname=rhel --grow
-# poweroff automatically at the end of the installation process
-poweroff
 # define packages to install
 %packages
 @core
@@ -49,17 +42,52 @@ kexec-tools
 # add 'kdump' add-on to the install
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 %end
-
 # install epel-release, ansible and git and clone the kragle source repository
 %post --log=/root/ks-post.log
+/bin/sed -i 's/^ONBOOT=no$/ONBOOT=yes/' /etc/sysconfig/network-scripts/ifcfg-e*
+cat > /tmp/postinstall.sh << EOF
+#!/bin/bash
 
-/usr/sbin/subscription-manager register --username <rhn_username> --password <rhn_password> --autosubscribe
+# restart the network
+systemctl restart network
+# Wait for network to come up when using NetworkManager.
+if service NetworkManager status >/dev/null 2>&1 && type -P nm-online; then
+    nm-online -q --timeout=10 || nm-online -q -x --timeout=30
+    [ "$?" -eq 0 ] || exit 1
+fi
+# show the network config
+ip addr
+# register the node.  Note that you should replace the following variables in this
+# command with valid RHN credentials:
+#     RHN_USERNAME with the username of an account with a valid subscription
+#     RHN_PASSWORD with the password for that account
+/usr/sbin/subscription-manager register --username RHN_USERNAME --password RHN_PASSWORD --autosubscribe
+# enable the rhel7-server-extras repository
 /usr/sbin/subscription-manager repos --enable=rhel-7-server-extras-rpms
-
+# install a few packages
 yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 yum -y install git ansible
-
-git clone https://git_username:git_password@github.com/csc/kragle
-
-ansible-playbook -i localhost, ansible/kragle/main.yml
+# setup localhost so that SSH will always succeed (without asking to verifyt he key)
+cat > ~/.ssh/config << EOF2
+Host localhost
+    Hostname localhost
+    StrictHostKeyChecking no
+EOF2
+chmod 400 ~/.ssh/config
+# clone the kragle repository
+cd /tmp
+git clone https://github.com/csc/kragle
+# run the main ansible playbook from the kragle project
+cd kragle
+ansible-playbook -i ansible/inventory/hosts.ini ansible/main.yml
+# and cleanup
+rm -f ~/.ssh/config
+sed -i --follow-symlinks '/postinstall/d' /etc/rc.local
+# and poweroff the system
+poweroff
+EOF
+echo bash /tmp/postinstall.sh >> /etc/rc.local
+chmod +x /tmp/postinstall.sh
+# This line needs to be added otherwise rc.local will not execute on boot
+chmod +x /etc/rc.d/rc.local
 %end

--- a/patch-files/iso-mods.patch
+++ b/patch-files/iso-mods.patch
@@ -1,16 +1,16 @@
 diff -Naur rhel-server-7.1-x86_64-orig/EFI/BOOT/grub.cfg rhel-server-7.1-x86_64-customized/EFI/BOOT/grub.cfg
 --- rhel-server-7.1-x86_64-orig/EFI/BOOT/grub.cfg	2015-02-19 07:42:07.000000000 -0800
-+++ rhel-server-7.1-x86_64-customized/EFI/BOOT/grub.cfg	2015-06-10 07:27:04.724520077 -0700
++++ rhel-server-7.1-x86_64-customized/EFI/BOOT/grub.cfg	2015-08-05 12:01:32.651239677 -0700
 @@ -14,18 +14,18 @@
  insmod part_gpt
  insmod ext2
-
+ 
 -set timeout=60
 +set timeout=5
  ### END /etc/grub.d/00_header ###
-
+ 
  search --no-floppy --set=root -l 'RHEL-7.1 Server.x86_64'
-
+ 
  ### BEGIN /etc/grub.d/10_linux ###
  menuentry 'Install Red Hat Enterprise Linux 7.1' --class fedora --class gnu-linux --class gnu --class os {
 -	linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=RHEL-7.1\x20Server.x86_64 quiet
@@ -26,21 +26,21 @@ diff -Naur rhel-server-7.1-x86_64-orig/EFI/BOOT/grub.cfg rhel-server-7.1-x86_64-
  submenu 'Troubleshooting -->' {
 diff -Naur rhel-server-7.1-x86_64-orig/isolinux/isolinux.cfg rhel-server-7.1-x86_64-customized/isolinux/isolinux.cfg
 --- rhel-server-7.1-x86_64-orig/isolinux/isolinux.cfg	2015-02-19 07:42:07.000000000 -0800
-+++ rhel-server-7.1-x86_64-customized/isolinux/isolinux.cfg	2015-06-10 08:42:04.936136234 -0700
++++ rhel-server-7.1-x86_64-customized/isolinux/isolinux.cfg	2015-08-05 12:01:32.651239677 -0700
 @@ -1,5 +1,5 @@
  default vesamenu.c32
 -timeout 600
 +timeout 50
-
+ 
  display boot.msg
-
+ 
 @@ -61,13 +61,13 @@
  label linux
    menu label ^Install Red Hat Enterprise Linux 7.1
    kernel vmlinuz
 -  append initrd=initrd.img inst.stage2=hd:LABEL=RHEL-7.1\x20Server.x86_64 quiet
 +  append initrd=initrd.img inst.stage2=hd:LABEL=RHEL-7.1\x20Server.x86_64
-
+ 
 -label check
 -  menu label Test this ^media & install Red Hat Enterprise Linux 7.1
 +label unattended
@@ -49,13 +49,13 @@ diff -Naur rhel-server-7.1-x86_64-orig/isolinux/isolinux.cfg rhel-server-7.1-x86
    kernel vmlinuz
 -  append initrd=initrd.img inst.stage2=hd:LABEL=RHEL-7.1\x20Server.x86_64 rd.live.check quiet
 +  append initrd=initrd.img inst.stage2=hd:LABEL=RHEL-7.1\x20Server.x86_64 ks=hd:LABEL=RHEL-7.1\x20Server.x86_64:/kickstart/ks-isolinux.cfg
-
+ 
  menu separator # insert an empty line
-
+ 
 diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-isolinux.cfg rhel-server-7.1-x86_64-customized/kickstart/ks-isolinux.cfg
 --- rhel-server-7.1-x86_64-orig/kickstart/ks-isolinux.cfg	1969-12-31 16:00:00.000000000 -0800
-+++ rhel-server-7.1-x86_64-customized/kickstart/ks-isolinux.cfg	2015-06-10 08:54:20.677063309 -0700
-@@ -0,0 +1,53 @@
++++ rhel-server-7.1-x86_64-customized/kickstart/ks-isolinux.cfg	2015-08-06 07:49:19.126748978 -0700
+@@ -0,0 +1,92 @@
 +#version=RHEL7
 +
 +# install a fresh system
@@ -91,8 +91,6 @@ diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-isolinux.cfg rhel-server-7.1
 +logvol swap  --fstype="swap" --size=8000 --name=swap --vgname=rhel
 +logvol /home  --fstype="xfs" --size=51200 --name=home --vgname=rhel
 +logvol /  --fstype="xfs" --size=1 --name=root --vgname=rhel --grow
-+# poweroff automatically at the end of the installation process
-+poweroff
 +# define packages to install
 +%packages
 +@core
@@ -103,17 +101,57 @@ diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-isolinux.cfg rhel-server-7.1
 +%end
 +# install epel-release, ansible and git and clone the kragle source repository
 +%post --log=/root/ks-post.log
-+/usr/sbin/subscription-manager register --username <rhn_username> --password <rhn_password> --autosubscribe
++/bin/sed -i 's/^ONBOOT=no$/ONBOOT=yes/' /etc/sysconfig/network-scripts/ifcfg-e*
++cat > /tmp/postinstall.sh << EOF
++#!/bin/bash
++
++# restart the network
++systemctl restart network
++# Wait for network to come up when using NetworkManager.
++if service NetworkManager status >/dev/null 2>&1 && type -P nm-online; then
++    nm-online -q --timeout=10 || nm-online -q -x --timeout=30
++    [ "$?" -eq 0 ] || exit 1
++fi
++# show the network config
++ip addr
++# register the node.  Note that you should replace the following variables in this
++# command with valid RHN credentials:
++#     RHN_USERNAME with the username of an account with a valid subscription
++#     RHN_PASSWORD with the password for that account
++/usr/sbin/subscription-manager register --username RHN_USERNAME --password RHN_PASSWORD --autosubscribe
++# enable the rhel7-server-extras repository
 +/usr/sbin/subscription-manager repos --enable=rhel-7-server-extras-rpms
++# install a few packages
 +yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 +yum -y install git ansible
-+git clone https://git_username:git_password@github.com/csc/kragle
-+ansible-playbook -i localhost, kragle/kragle.yml
++# setup localhost so that SSH will always succeed (without asking to verifyt he key)
++cat > ~/.ssh/config << EOF2
++Host localhost
++    Hostname localhost
++    StrictHostKeyChecking no
++EOF2
++chmod 400 ~/.ssh/config
++# clone the kragle repository
++cd /tmp
++git clone https://github.com/csc/kragle
++# run the main ansible playbook from the kragle project
++cd kragle
++ansible-playbook -i ansible/inventory/hosts.ini ansible/main.yml
++# and cleanup
++rm -f ~/.ssh/config
++sed -i --follow-symlinks '/postinstall/d' /etc/rc.local
++# and poweroff the system
++poweroff
++EOF
++echo bash /tmp/postinstall.sh >> /etc/rc.local
++chmod +x /tmp/postinstall.sh
++# This line needs to be added otherwise rc.local will not execute on boot
++chmod +x /etc/rc.d/rc.local
 +%end
 diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-uefi.cfg rhel-server-7.1-x86_64-customized/kickstart/ks-uefi.cfg
 --- rhel-server-7.1-x86_64-orig/kickstart/ks-uefi.cfg	1969-12-31 16:00:00.000000000 -0800
-+++ rhel-server-7.1-x86_64-customized/kickstart/ks-uefi.cfg	2015-06-10 08:52:50.479901159 -0700
-@@ -0,0 +1,54 @@
++++ rhel-server-7.1-x86_64-customized/kickstart/ks-uefi.cfg	2015-08-06 07:49:24.286557875 -0700
+@@ -0,0 +1,93 @@
 +#version=RHEL7
 +
 +# install a fresh system
@@ -150,8 +188,6 @@ diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-uefi.cfg rhel-server-7.1-x86
 +logvol swap  --fstype="swap" --size=8000 --name=swap --vgname=rhel
 +logvol /home  --fstype="xfs" --size=51200 --name=home --vgname=rhel
 +logvol /  --fstype="xfs" --size=1 --name=root --vgname=rhel --grow
-+# poweroff automatically at the end of the installation process
-+poweroff
 +# define packages to install
 +%packages
 +@core
@@ -162,10 +198,50 @@ diff -Naur rhel-server-7.1-x86_64-orig/kickstart/ks-uefi.cfg rhel-server-7.1-x86
 +%end
 +# install epel-release, ansible and git and clone the kragle source repository
 +%post --log=/root/ks-post.log
-+/usr/sbin/subscription-manager register --username <rhn_username> --password <rhn_password> --autosubscribe
++/bin/sed -i 's/^ONBOOT=no$/ONBOOT=yes/' /etc/sysconfig/network-scripts/ifcfg-e*
++cat > /tmp/postinstall.sh << EOF
++#!/bin/bash
++
++# restart the network
++systemctl restart network
++# Wait for network to come up when using NetworkManager.
++if service NetworkManager status >/dev/null 2>&1 && type -P nm-online; then
++    nm-online -q --timeout=10 || nm-online -q -x --timeout=30
++    [ "$?" -eq 0 ] || exit 1
++fi
++# show the network config
++ip addr
++# register the node.  Note that you should replace the following variables in this
++# command with valid RHN credentials:
++#     RHN_USERNAME with the username of an account with a valid subscription
++#     RHN_PASSWORD with the password for that account
++/usr/sbin/subscription-manager register --username RHN_USERNAME --password RHN_PASSWORD --autosubscribe
++# enable the rhel7-server-extras repository
 +/usr/sbin/subscription-manager repos --enable=rhel-7-server-extras-rpms
++# install a few packages
 +yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 +yum -y install git ansible
-+git clone https://git_username:git_password@github.com/csc/kragle
-+ansible-playbook -i localhost, ansible/kragle/main.yml
++# setup localhost so that SSH will always succeed (without asking to verifyt he key)
++cat > ~/.ssh/config << EOF2
++Host localhost
++    Hostname localhost
++    StrictHostKeyChecking no
++EOF2
++chmod 400 ~/.ssh/config
++# clone the kragle repository
++cd /tmp
++git clone https://github.com/csc/kragle
++# run the main ansible playbook from the kragle project
++cd kragle
++ansible-playbook -i ansible/inventory/hosts.ini ansible/main.yml
++# and cleanup
++rm -f ~/.ssh/config
++sed -i --follow-symlinks '/postinstall/d' /etc/rc.local
++# and poweroff the system
++poweroff
++EOF
++echo bash /tmp/postinstall.sh >> /etc/rc.local
++chmod +x /tmp/postinstall.sh
++# This line needs to be added otherwise rc.local will not execute on boot
++chmod +x /etc/rc.d/rc.local
 +%end


### PR DESCRIPTION
This PR fixes issues associated with kickstart and patch files during recent work to add ansible playbook runs to the kickstart files used when performing an unattended install of RHEL 7.1 from a thumb drive