### PR TITLE
kragle - moving things out of wiley

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,4 +1,9 @@
 ---
+#Kragle common vars
+auto_deploy_node: 172.17.16.10
+hanlon_base_url: http://{{ auto_deploy_node }}:8026/hanlon/api/v1/
+dns1: 192.168.70.3
+
 # Kragle site_discovery vars
 pxe_subnet_name: 172.17.16.0
 pxe_subnet_mask: 255.255.255.0

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,0 +1,13 @@
+---
+# Kragle site_discovery vars
+pxe_subnet_name: 172.17.16.0
+pxe_subnet_mask: 255.255.255.0
+pxe_gateway: 172.17.16.1
+pxe_dhcp_range_start: 172.17.16.20
+pxe_dhcp_range_end: 172.17.16.50
+domain_name: lordbusiness
+
+hnl_mk_image: hnl_mk_debug-image.2.0.1.iso
+hnl_mk_source: https://github.com/csc/Hanlon-Microkernel/releases/download/v2.0.1/
+hnl_mk_local_path: /opt/hanlon/image/
+hnl_mk_path: /home/hanlon/image/{{ hnl_mk_image }}

--- a/ansible/library/hanlon_active_model.py
+++ b/ansible/library/hanlon_active_model.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+module: hanlon_active_model_facts
+short_description: Get the current status of the active_model associated with a host.
+description:
+    - A Hanlon model describes how a bare metal server operating system should be configured when provisioning
+    this module adds a model to Hanlon.
+version_added: null
+author: Joseph Callen
+requirements:
+    - requests
+    - Hanlon server
+options:
+    base_url:
+        description:
+            - The url to the Hanlon RESTful base endpoint
+        required: true
+        default: null
+        aliases: []
+    smbios_uuid:
+        description:
+            - The UUID or hardware ID from the system BIOS
+        required: true
+        default: null
+        aliases: []
+'''
+
+import requests
+
+
+def state_destroy_active_model(module):
+    base_url = module.params['base_url']
+    uuid = module.params['uuid']
+
+    uri = "%s/active_model/%s" % (base_url, uuid)
+
+    try:
+        if not module.check_mode:
+            req = requests.delete(uri)
+            if req.status_code == 200:
+                module.exit_json(changed=True)
+            else:
+                module.fail_json(msg="Unknown error", apierror=req.text)
+        module.exit_json(changed=True)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def check_active_model_state(module):
+
+    base_url = module.params['base_url']
+    smbios_uuid = module.params['smbios_uuid']
+
+    url = "%s/active_model?hw_id=%s" % (base_url, smbios_uuid)
+
+    try:
+        req = requests.get(url)
+        if req.status_code == 200:
+            active_model = req.json()
+            if 'response' in active_model:
+                if '@model' in active_model['response']:
+                    if '@current_state' in active_model['response']['@model']:
+                        current_state = active_model['response']['@model']['@current_state']
+                    else:
+                        current_state = ""
+                    if '@node_ip' in active_model['response']['@model']:
+                        node_ip = active_model['response']['@model']['@node_ip']
+                    else:
+                        node_ip = ""
+                    module.params['uuid'] = active_model['response']['@uuid']
+                    module.params['current_state'] = current_state
+                    module.params['node_ip'] = node_ip
+
+                    return 'present'
+        elif req.status_code == 400:
+            module.params['uuid'] = None
+            module.params['current_state'] = None
+            module.params['node_ip'] = None
+            return 'absent'
+        else:
+            module.fail_json(msg="Unknown error", apierror=req.text)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def state_exit_unchanged(module):
+    uuid = module.params['uuid']
+    current_state = module.params['current_state']
+    node_ip = module.params['node_ip']
+
+    module.exit_json(changed=False, current_state=current_state, node_ip=node_ip, uuid=uuid)
+
+
+def create_argument_spec():
+    argument_spec = dict()
+
+    argument_spec.update(
+        base_url=dict(required=True),
+        smbios_uuid=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'], type='str')
+    )
+    return argument_spec
+
+
+def main():
+    argument_spec = create_argument_spec()
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    hanlon_active_model_states = {
+        'absent': {
+            'absent': state_exit_unchanged,
+            'present': state_destroy_active_model
+        },
+        'present': {
+            'absent': state_exit_unchanged,
+            'present': state_exit_unchanged
+        }
+    }
+
+    hanlon_active_model_states[module.params['state']][check_active_model_state(module)](module)
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/hanlon_image.py
+++ b/ansible/library/hanlon_image.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+module: hanlon_image
+short_description: Add a new image to Hanlon
+description:
+    -
+version_added: null
+author: Joseph Callen
+requirements:
+    - requests
+    - Hanlon server
+options:
+    base_url:
+        description:
+            - The url to the Hanlon RESTful base endpoint
+        required: true
+        default: null
+        aliases: []
+    type:
+        description:
+            - The available OS templates for use with Hanlon.  From the CLI ./hanlon model templates
+        required: true
+        default: null
+        aliases: []
+    path:
+        description:
+            - The path to an ISO image for either an OS, hypervisor or microkernel
+        required: true
+        default: null
+        aliases: []
+    name:
+        description: null
+        required: false
+        default: null
+        aliases: []
+    version:
+        description:
+            - The version of the OS
+        required: false
+        default: null
+        aliases: []
+
+notes:
+    - This module should run from a system that can access Hanlon directly. Either by using local_action, or using delegate_to.
+'''
+
+import requests
+
+
+def state_exit_unchanged(module):
+    uuid = module.params['uuid']
+    module.exit_json(changed=False, uuid=uuid)
+
+
+def state_destroy_image(module):
+    base_url = module.params['base_url']
+    uuid = module.params['uuid']
+
+    uri = "%s/image/%s" % (base_url, uuid)
+
+    try:
+        if not module.check_mode:
+            req = requests.delete(uri)
+            if req.status_code == 200:
+                module.exit_json(changed=True)
+            else:
+                module.fail_json(msg="Unknown Hanlon API error", apierror=req.text)
+        module.exit_json(changed=True)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+    module.exit_json(changed=False)
+
+
+def state_create_image(module):
+    base_url = module.params['base_url']
+    url = "%s/image" % base_url
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+    uuid = None
+
+    payload = {
+        'type': module.params['type'],
+        'path': module.params['path']
+    }
+
+    if module.params['type'] == 'os':
+        payload.update({
+            'name': module.params['name'],
+            'version': module.params['version']
+        })
+
+    try:
+        if not module.check_mode:
+            req = requests.post(url, data=json.dumps(payload), headers=headers)
+            if req.status_code == 201:
+                json_result = req.json()
+                uuid = json_result['response']['@uuid']
+                module.exit_json(changed=True, uuid=uuid)
+            else:
+                module.fail_json(msg="Unknown Hanlon API error", apierror=req.text)
+        module.exit_json(changed=True, uuid=uuid)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def hanlon_get_request(uri):
+    req = requests.get(uri)
+    if req.status_code == 200:
+        json_result = req.json()
+        return json_result
+
+
+def check_image_state(module):
+    base_url = module.params['base_url']
+    uri = "%s/image" % base_url
+    module.params['uuid'] = None
+    path = module.params['path']
+
+    path_split = path.split("/")
+    filename = path_split[len(path_split)-1]
+
+    try:
+        json_result = hanlon_get_request(uri)
+
+        for response in json_result['response']:
+            uri = response['@uri']
+            image = hanlon_get_request(uri)
+            image_response = image['response']
+
+            if image_response.get('@filename') == filename:
+                module.params['uuid'] = image_response['@uuid']
+                return 'present'
+        return 'absent'
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def create_argument_spec():
+    argument_spec = dict()
+
+    argument_spec.update(
+        base_url=dict(required=True, type='str'),
+        type=dict(required=True, type='str'),
+        path=dict(required=True, type='str'),
+        name=dict(required=False, type='str'),
+        version=dict(required=False, type='str'),
+        state=dict(default='present', choices=['present', 'absent'], type='str'),
+    )
+    return argument_spec
+
+
+def main():
+    argument_spec = create_argument_spec()
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    hanlon_image_states = {
+        'absent': {
+            'absent': state_exit_unchanged,
+            'present': state_destroy_image
+        },
+        'present': {
+            'absent': state_create_image,
+            'present': state_exit_unchanged,
+            }
+    }
+    image_state = check_image_state(module)
+
+    hanlon_image_states[module.params['state']][image_state](module)
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/hanlon_model.py
+++ b/ansible/library/hanlon_model.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+module: hanlon_model
+short_description: Add a new model to Hanlon
+description:
+    - A Hanlon model describes how a bare metal server operating system should be configured when provisioned.
+    This module adds a model to Hanlon.
+version_added: 2.0
+author: Joseph Callen
+requirements:
+    - requests
+    - Hanlon server
+options:
+    base_url:
+        description:
+            - The url to the Hanlon RESTful base endpoint
+        required: true
+    template:
+        description:
+            - The available OS templates for use with Hanlon.  From the CLI ./hanlon model templates
+        required: true
+    label:
+        description:
+            - Name of the model
+        required: true
+notes:
+    - This module should run from a system that can access Hanlon directly. Either by using local_action, or using delegate_to.
+    - The options for this module are dynamic based on the template type.  The req_metadata_hash and opt_metadata_hash keys map to options
+'''
+
+import requests
+
+
+def _jsonify(data):
+    """
+    Since I am doing things a little different as certain points in code execution I cannot use
+    the provided AnsibleModule methods.  Instead I am modifying for specific use.
+    https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py
+    :param data:
+    :return json:
+
+    """
+    for encoding in ("utf-8", "latin-1", "unicode_escape"):
+        try:
+            return json.dumps(data, encoding=encoding)
+        # Old systems using simplejson module does not support encoding keyword.
+        except TypeError, e:
+            return json.dumps(data)
+        except UnicodeDecodeError, e:
+            continue
+    _fail_json(msg='Invalid unicode encoding encountered')
+
+
+def _fail_json(**kwargs):
+    """
+    :param kwargs:
+    :return:
+    """
+
+    kwargs['failed'] = True
+    print _jsonify(kwargs)
+    sys.exit(1)
+
+
+def peek_params():
+    """
+    Copied code from _load_params(self) - https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py
+    So we are going to cheat a little.  In order to use the AnsibleModule we will peek at
+    the MODULE_ARGS to determine the basic configuration, model template being used and the URI of the Hanlon server.
+
+    :returns base_url, template
+    """
+    base_url = ""
+    template = ""
+    args = MODULE_ARGS
+    items = shlex.split(args)
+
+    for x in items:
+        try:
+            (k, v) = x.split("=", 1)
+            if k == 'base_url':
+                base_url = v
+            elif k == 'template':
+                template = v
+        except Exception, e:
+            _fail_json(msg="this module requires key=value arguments (%s)" % items)
+
+    if len(base_url) == 0:
+        _fail_json(msg="missing base_url argument")
+    if len(template) == 0:
+        _fail_json(msg="missing template argument")
+
+    return base_url, template
+
+
+def create_new_hanlon_model(module):
+    """
+    This function creates the body of the POST request to the Hanlon server creating the model via the
+    parameters provided by the AnsibleModule
+
+    :param module:
+    :param metadata_hash:
+    :return json_result:
+    """
+    metadata_hash = module.params['metadata_hash']
+    req_metadata_params = dict()
+
+    base_url = module.params['base_url']
+    url = "%s/model" % base_url
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+    # We need to generate the req_metadata_params to POST into Hanlon
+    for metadata in metadata_hash:
+        # Because we have optional metadata we only want to include params
+        # that have values assigned
+        if metadata in module.params:
+            if module.params[metadata]:
+                if len(module.params[metadata]) != 0:
+                    req_metadata_params.update({metadata: module.params[metadata]})
+
+    payload = {
+        'label': module.params['label'],
+        'template': module.params['template'],
+        'req_metadata_params': req_metadata_params
+    }
+
+    # If we are using the boot_local and discover_only models
+    # we do not want the image_uuid as its not required.
+    # All other models it is required
+    if (module.params['template'] != 'boot_local') or (module.params['template'] != 'discover_only'):
+        payload.update({'image_uuid': module.params['image_uuid']})
+
+    try:
+        req = requests.post(url, data=json.dumps(payload), headers=headers)
+        json_result = req.json()
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+    return json_result
+
+
+def create_argument_spec(base_url, model_template):
+    """
+
+    :param base_url:
+    :param model_template:
+    :returns argument_spec, metadata_hash:
+    """
+
+    # Hanlon has two types of metadata: required and optional
+    metadata_types = "@req_metadata_hash", "@opt_metadata_hash"
+    metadata_hash = []
+    argument_spec = dict()
+
+    # Each OS template is defined, lets GET the current model template that we are working with
+    url = "%s/model/templates/%s" % (base_url, model_template)
+
+    # There is no image when we are using boot_local or discover_only models
+    if (model_template == 'boot_local') or (model_template == 'discover_only'):
+        argument_spec.update(image_uuid=dict(required=False))
+    else:
+        argument_spec.update(image_uuid=dict(required=True))
+
+    argument_spec.update(
+        base_url=dict(required=True),
+        template=dict(required=True),
+        label=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'], type='str')
+    )
+
+    try:
+        req = requests.get(url)
+        if req.status_code != 200:
+            _fail_json(msg=req.text)
+
+        template = req.json()
+    except requests.ConnectionError as connect_error:
+        _fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        _fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        _fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+    try:
+        for md_type in metadata_types:
+            for metadata in template['response'][md_type]:
+                # When we generate the req_metadata_params I will only want module.params key values
+                # from the metadata.
+                metadata_hash.append(metadata[1:])
+                argument_spec.update({
+                    metadata[1:]: dict(
+                        {'required': template['response'][md_type][metadata]['required']}
+                    )})
+    except Exception as e:
+        _fail_json(msg=e.message)
+
+    return argument_spec, metadata_hash
+
+
+def state_exit_unchanged(module):
+    uuid = module.params['uuid']
+    module.exit_json(changed=False, uuid=uuid)
+
+
+def state_destroy_model(module):
+    base_url = module.params['base_url']
+    uuid = module.params['uuid']
+
+    uri = "%s/model/%s" % (base_url, uuid)
+
+    try:
+        req = requests.delete(uri)
+        if req.status_code == 200:
+            module.exit_json(changed=True)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+    module.exit_json(changed=False)
+
+
+def state_create_model(module):
+    new_model = create_new_hanlon_model(module)
+    uuid = new_model['response']['@uuid']
+    module.exit_json(changed=True, uuid=uuid)
+
+
+def hanlon_get_request(uri):
+    req = requests.get(uri)
+    if req.status_code == 200:
+        json_result = req.json()
+        return json_result
+
+
+def check_model_state(module):
+    base_url = module.params['base_url']
+    model_name = module.params['label']
+
+    uri = "%s/model" % base_url
+    try:
+        json_result = hanlon_get_request(uri)
+
+        for response in json_result['response']:
+            uri = response['@uri']
+            model = hanlon_get_request(uri)
+            model_response = model['response']
+            if model_response['@label'] == model_name:
+                return 'present', model_response['@uuid']
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+    return 'absent', None
+
+
+def main():
+    (base_url, model_template) = peek_params()
+    argument_spec, metadata_hash = create_argument_spec(base_url, model_template)
+    module = AnsibleModule(argument_spec=argument_spec)
+    module.params['metadata_hash'] = metadata_hash
+
+    hanlon_model_states = {
+        'absent': {
+            'absent': state_exit_unchanged,
+            'present': state_destroy_model
+        },
+        'present': {
+            'absent': state_create_model,
+            'present': state_exit_unchanged
+        }
+    }
+    model_state, uuid = check_model_state(module)
+    module.params['uuid'] = uuid
+    hanlon_model_states[module.params['state']][model_state](module)
+
+
+from ansible.module_utils.basic import *
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/hanlon_node.py
+++ b/ansible/library/hanlon_node.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+module: hanlon_node
+short_description: Change the current power state of a node
+description:
+    - This module checks the current power state of a node and allows it to be changed.
+version_added: null
+author: Joseph Callen
+requirements:
+    - requests
+    - Hanlon server
+options:
+    base_url:
+        description:
+            - The url to the Hanlon RESTful base endpoint
+        required: true
+        default: null
+        aliases: []
+    smbios_uuid:
+        description:
+            - The UUID or hardware ID from the system BIOS
+        required: true
+        default: null
+        aliases: []
+    power_command:
+        description:
+            - The current power state of the node
+        required: true
+    ipmi_username:
+        description:
+            - The user credential used for ipmi commands
+        required: true
+    ipmi_password:
+        description:
+            - The password credential used for ipmi commands
+    ipmi_options:
+        description:
+            - JSON string for IPMI options
+'''
+
+import requests
+import urllib
+
+
+def change_power_state(module, current_state):
+    base_url = module.params['base_url']
+    url = "%s/node/power" % (base_url)
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+    if module.params['power_state'] == 'reset':
+        if current_state == 'on':
+            power_command = 'reset'
+        else:
+            power_command = 'on'
+    else:
+        power_command = module.params['power_state']
+
+    payload = {
+        'hw_id': module.params['smbios_uuid'],
+        'power_command': power_command,
+        'ipmi_username': module.params['username'],
+        'ipmi_password': module.params['password'],
+        }
+
+    if module.params['ipmi_options'] is not None:
+        payload.update({'ipmi_options': str(module.params['ipmi_options'])})
+
+    try:
+        if not module.check_mode:
+            req = requests.post(url, data=json.dumps(payload), headers=headers)
+            if req.status_code == 201:
+                json_result = req.json()
+                module.exit_json(changed=True)
+            else:
+                module.fail_json(msg="Unknown Hanlon API error", apierror=req.text)
+        module.exit_json(changed=True, uuid=None)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+def check_node_power_state(module):
+
+    base_url = module.params['base_url']
+    smbios_uuid = module.params['smbios_uuid']
+    power_state = module.params['power_state']
+    username = module.params['username']
+    password = module.params['password']
+
+    if module.params['ipmi_options'] is not None:
+        ipmi_options = urllib.quote(str(module.params['ipmi_options']))
+        url = "%s/node/power?hw_id=%s&ipmi_username=%s&ipmi_password=%s&ipmi_options=%s" % (base_url, smbios_uuid, username, password, ipmi_options)
+    else:
+        url = "%s/node/power?hw_id=%s&ipmi_username=%s&ipmi_password=%s" % (base_url, smbios_uuid, username, password)
+
+    try:
+        req = requests.get(url)
+        if req.status_code == 200:
+            active_model = req.json()
+            if 'response' in active_model:
+                if 'Status' in active_model['response']:
+                    current_state = active_model['response']['Status']
+                    if current_state == power_state:
+                        module.exit_json(changed=False)
+                    else:
+                        change_power_state(module, current_state)
+
+        else:
+            module.fail_json(msg="Unknown error", apierror=req.text)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def create_argument_spec():
+    argument_spec = dict()
+
+    argument_spec.update(
+        base_url=dict(required=True),
+        smbios_uuid=dict(required=True),
+        username=dict(required=True, type='str'),
+        password=dict(required=True, type='str', no_log=True),
+        power_state=dict(required=True, choices=['on', 'off', 'reset'], type='str'),
+        ipmi_options=dict(required=False, type='str')
+    )
+    return argument_spec
+
+
+def main():
+    argument_spec = create_argument_spec()
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    check_node_power_state(module)
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/ansible/library/hanlon_policy.py
+++ b/ansible/library/hanlon_policy.py
@@ -1,0 +1,279 @@
+#!/usr/bin/python
+DOCUMENTATION = '''
+---
+# If a key doesn't apply to your module (ex: choices, default, or
+# aliases) you can use the word 'null', or an empty list, [], where
+# appropriate.
+module: hanlon_policy
+short_description: Add a new policy to Hanlon
+description:
+    - A Hanlon policy describes the rules for binding a node to operating system model.
+version_added: null
+author: Joseph Callen, Russell Teague
+notes: null
+requirements:
+    - Hanlon server
+options:
+    base_url:
+        description:
+            - The url to the Hanlon RESTful base endpoint
+        required: true
+        default: null
+        aliases: []
+    template:
+        description:
+            - The available policy templates for use with Hanlon.  From the CLI ./hanlon policy templates
+        required: true
+        default: null
+        aliases: []
+    label:
+        description:
+            - The name of the policy
+        required: true
+        default: null
+        aliases: []
+    model_uuid:
+        description:
+            - The model UUID to use for this policy
+        required: true
+        default: null
+        aliases: []
+    tags:
+        description:
+            - The tags which should match the node for binding
+        required: true
+        default: null
+        aliases: []
+    enabled:
+        description:
+            - The state of the policy
+        required: false
+        default: true
+        aliases: []
+    line_number:
+        description:
+            - The line number in the policy table the policy should exist
+        required: false
+        default: null
+        aliases: []
+    is_default:
+        description:
+            - Set policy as system default
+        required: false
+        default: null
+        aliases: []
+notes:
+    - This module should run from a system that can access Hanlon directly. Either by using local_action, or using delegate_to.
+'''
+
+import requests
+
+
+def state_create_policy(module):
+    base_url = module.params['base_url']
+    url = "%s/policy" % base_url
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+    payload = {
+        'template':   module.params['policy_template'],
+        'label':      module.params['label'],
+        'model_uuid': module.params['model_uuid'],
+        }
+
+    if None in payload.values():
+        module.fail_json(msg="Missing required arguments for creating a new policy.")
+
+    if module.params['enabled'] is not None:
+        payload.update({
+            'enabled': module.params['enabled']
+        })
+    if module.params['is_default'] is not None:
+        payload.update({
+            'is_default': module.params['is_default']
+        })
+    if module.params['tags'] is not None:
+        payload.update({
+            'tags': module.params['tags']
+        })
+    if module.params['maximum'] is not None:
+        payload.update({
+            'maximum': str(module.params['maximum'])
+        })
+    if module.params['line_number'] is not None:
+        payload.update({'line_number': str(module.params['line_number'])})
+
+    try:
+        if not module.check_mode:
+            req = requests.post(url, data=json.dumps(payload), headers=headers)
+            if req.status_code == 201:
+                json_result = req.json()
+                uuid = json_result['response']['@uuid']
+                module.exit_json(changed=True, uuid=uuid)
+            else:
+                module.fail_json(msg="Unknown Hanlon API error", apierror=req.text)
+        module.exit_json(changed=True, uuid=None)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def hanlon_get_request(uri):
+    req = requests.get(uri)
+    if req.status_code == 200:
+        json_result = req.json()
+        return json_result
+
+
+def check_diff(policy_response, module):
+    policy_name = module.params['label']
+    if policy_response['@label'] == policy_name:
+        module.params['uuid'] = policy_response['@uuid']
+
+        # The Hanlon API is a little screwy with tags
+        # the PUT/POST wants a comma delimited string
+        # the JSON result from a Policy query is an array/list of
+        # strings, adding to a complication when comparing.
+        # Along with the fact that the return type of integers
+        # is actually a string.
+
+        if module.params['enabled'] is not None:
+            if module.params['enabled'] != policy_response['@enabled']:
+                return 'update'
+        if module.params['line_number'] is not None:
+            if str(module.params['line_number']) != str(policy_response['@line_number']):
+                return 'update'
+        if module.params['tags'] is not None:
+            tags = module.params['tags'].split(",")
+            if tags != policy_response['@tags']:
+                return 'update'
+        if module.params['maximum'] is not None:
+            if str(module.params['maximum']) != str(policy_response['@maximum_count']):
+                return 'update'
+        return 'present'
+    else:
+        return 'absent'
+
+
+def check_policy_state(module):
+    base_url = module.params['base_url']
+    uri = "%s/policy" % base_url
+    module.params['uuid'] = None
+    state = 'absent'
+
+    try:
+        json_result = hanlon_get_request(uri)
+
+        for response in json_result['response']:
+            uri = response['@uri']
+            policy = hanlon_get_request(uri)
+            policy_response = policy['response']
+            state = check_diff(policy_response, module)
+            if state is not 'absent':
+                break
+        return state
+
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def state_update_policy(module):
+    base_url = module.params['base_url']
+    uuid = module.params['uuid']
+    url = "%s/policy/%s" % (base_url, uuid)
+    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+    payload = {'enabled': module.params['enabled']}
+
+    if module.params['line_number'] is not None:
+        payload.update({'new_line_number': str(module.params['line_number'])})
+    if module.params['tags'] is not None:
+        payload.update({'tags': module.params['tags']})
+    if module.params['maximum'] is not None:
+        payload.update({'maximum': str(module.params['maximum'])})
+
+    try:
+        if not module.check_mode:
+            req = requests.put(url, data=json.dumps(payload), headers=headers)
+            if req.status_code == 200:
+                module.exit_json(changed=True, uuid=uuid)
+            else:
+                module.fail_json(msg="Unknown Hanlon API error", apierror=req.text)
+        module.exit_json(changed=True, uuid=uuid)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def state_exit_unchanged(module):
+    uuid = module.params['uuid']
+    module.exit_json(changed=False, uuid=uuid)
+
+
+def state_destroy_policy(module):
+    base_url = module.params['base_url']
+    uuid = module.params['uuid']
+
+    uri = "%s/policy/%s" % (base_url, uuid)
+
+    try:
+        if not module.check_mode:
+            req = requests.delete(uri)
+            if req.status_code == 200:
+                module.exit_json(changed=True)
+            else:
+                module.fail_json(msg="Unknown error", apierror=req.text)
+        module.exit_json(changed=True)
+    except requests.ConnectionError as connect_error:
+        module.fail_json(msg="Connection Error; confirm Hanlon base_url.", apierror=str(connect_error))
+    except requests.Timeout as timeout_error:
+        module.fail_json(msg="Timeout Error; confirm status of Hanlon server", apierror=str(timeout_error))
+    except requests.RequestException as request_exception:
+        module.fail_json(msg="Unknown Request library failure", apierror=str(request_exception))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            base_url=dict(required=True, type='str'),
+            policy_template=dict(required=False, type='str'),
+            label=dict(required=True, type='str'),
+            model_uuid=dict(required=False, type='str'),
+            tags=dict(required=False, type='str'),
+            enabled=dict(required=False, type='bool', default=True),
+            line_number=dict(required=False, type='int'),
+            is_default=dict(required=False, type='bool'),
+            maximum=dict(required=False, type='int'),
+            state=dict(required=False, default='present', choices=['present', 'absent'], type='str')
+        ), supports_check_mode=True
+    )
+
+    hanlon_policy_states = {
+        'absent': {
+            'absent': state_exit_unchanged,
+            'present': state_destroy_policy
+        },
+        'present': {
+            'absent': state_create_policy,
+            'present': state_exit_unchanged,
+            'update': state_update_policy
+        }
+    }
+    policy_state = check_policy_state(module)
+
+    hanlon_policy_states[module.params['state']][policy_state](module)
+
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -6,7 +6,9 @@
   ignore_errors: true
 
 - name: install support packages
-  yum: pkg={{ item }} state=present
+  yum:
+    pkg: "{{ item }}"
+    state: present
   with_items:
     - ntp
     - vim
@@ -33,6 +35,11 @@
   file:
     path: /root/.ssh/
     state: directory
+
+- name: Create SSH Key Pair for root user
+      user:
+        name: root
+        generate_ssh_key: yes
 
 - name: copy .ssh/config
   copy:

--- a/ansible/roles/dhcp-server/handlers/main.yml
+++ b/ansible/roles/dhcp-server/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart dhcpd
+  service:
+    name: dhcpd
+    state: restarted

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -15,5 +15,5 @@
 - name: enable dhcpd service
   service:
     name: dhcpd
-    state: running
+    state: started
     enabled: true

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -15,5 +15,5 @@
 - name: enable dhcpd service
   service:
     name: dhcpd
-    state: restarted
+    state: started
     enabled: true

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -15,5 +15,4 @@
 - name: enable dhcpd service
   service:
     name: dhcpd
-    state: started
     enabled: true

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: install dhcp server package
+  yum:
+    name: dhcp
+    state: present
+
+- name: setup dhcpd.conf
+  template:
+    src: dhcpd.conf.j2
+    dest: /etc/dhcp/dhcpd.conf
+    mode: 644
+  notify:
+  - restart dhcpd
+
+- name: enable dhcpd service
+  service:
+    name: dhcpd
+    state: running
+    enabled: true

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -15,4 +15,5 @@
 - name: enable dhcpd service
   service:
     name: dhcpd
+    state: restarted
     enabled: true

--- a/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
+++ b/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
@@ -1,0 +1,30 @@
+# dhcpd.conf
+#
+
+default-lease-time 600;
+max-lease-time 7200;
+
+authoritative;
+
+option hanlon_server code 224 = ip-address;
+option hanlon_port code 225 = unsigned integer 16;
+option hanlon_base_uri code 226 = text;
+
+subnet {{ pxe_subnet_name }} netmask {{ pxe_subnet_mask }} {
+    range                       {{ pxe_dhcp_range_start }} {{ pxe_dhcp_range_end }};
+    option routers              {{ pxe_gateway }};
+    option subnet-mask          {{ pxe_subnet_mask }};
+    option domain-name          "{{ domain_name }}";
+    option domain-name-servers  {{ dns1 }};
+    next-server                 {{ auto_deploy_node }};
+    option tftp-server-name     "{{ auto_deploy_node }}";
+    option hanlon_server        {{ auto_deploy_node }};
+    option hanlon_port          8026;
+    option hanlon_base_uri      "/hanlon/api/v1";
+
+    if exists user-class and option user-class = "iPXE" {
+        filename "hanlon.ipxe";
+    } else {
+        filename "undionly.kpxe";
+    }
+}

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -6,10 +6,6 @@
     - dhcp-server
 
   tasks:
-    - name: Create SSH Key Pair for root user
-      user:
-        name: root
-        generate_ssh_key: yes
 
     - name: Check for local copy of Hanlon Microkernel
       stat:

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -1,0 +1,44 @@
+---
+# This playbook sets up the environment for discovery of all nodes
+- name: Configure deployment node for site discovery
+  hosts: localhost
+  roles:
+    - dhcp-server
+
+  tasks:
+    - name: Create SSH Key Pair for root user
+      user:
+        name: root
+        generate_ssh_key: yes
+
+    - name: Check for local copy of Hanlon Microkernel
+      stat:
+        path: "{{ hnl_mk_local_path }}{{ hnl_mk_image }}"
+      register: hnl_mk
+
+    - name: Download Hanlon Microkernel
+      get_url:
+        url: "{{ hnl_mk_source }}{{ hnl_mk_image }}"
+        dest: "{{ hnl_mk_local_path }}"
+      when: not hnl_mk.stat.exists
+
+    - name: Add a Microkernel Image to Hanlon
+      hanlon_image:
+        base_url: "{{ hanlon_base_url }}"
+        type: mk
+        path: "{{ hnl_mk_path }}"
+
+    - name: Add a Discover Only Model to Hanlon
+      hanlon_model:
+        base_url: "{{ hanlon_base_url }}"
+        template: discover_only
+        label: discover_only_model
+      register: model
+
+    - name: Add a Discover Only Policy to Hanlon
+      hanlon_policy:
+        base_url: "{{ hanlon_base_url }}"
+        policy_template: discover_only
+        label: discover_only_policy
+        model_uuid: "{{ model.uuid }}"
+        is_default: true

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -1,0 +1,100 @@
+---
+- name: Start Hanlon Docker Environment
+  hosts: localhost
+  vars:
+    hanlon_resource: "/opt/hanlon"
+    docker_network: "{{ ansible_docker0.ipv4.network }}"
+    local_network: "{{ ansible_default_ipv4.network }}"
+    hanlon_subnets: "{{ local_network }}/24,{{ docker_network }}/16"
+    docker_api_version: 1.18
+
+  tasks:
+    - name: Ansible Docker Requirements
+      pip:
+        name: "{{ item }}"
+        extra_args: "-I"
+      with_items:
+      - six==1.4.1
+      - docker-py==1.1.0
+      - requests==2.7.0
+
+    - name: Clean up existing containers
+      docker:
+        docker_api_version: "{{ docker_api_version }}"
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: absent
+      with_items:
+        - { name: hanlon-mongo, image: mongo }
+#        - { name: hanlon-cassandra, image: tobert/cassandra }
+        - { name: hanlon-server, image: cscdock/hanlon }
+        - { name: hanlon-atftpd, image: cscdock/atftpd }
+
+    - name: Start Mongo Container
+      docker:
+        docker_api_version: "{{ docker_api_version }}"
+        name: hanlon-mongo
+        image: mongo
+        pull: always
+        state: started
+        command: mongod --smallfiles
+        volumes: "{{ hanlon_resource }}/data/db:/data/db"
+
+#    - name: Start Cassandra Container
+#      docker:
+#        docker_api_version: "{{ docker_api_version }}"
+#        name: hanlon-cassandra
+#        image: tobert/cassandra
+#        pull: always
+#        state: started
+#        volumes: "{{ hanlon_resource }}/data/db:/data"
+#
+#    - name: Wait for Cassandra Server to start
+#      command: docker exec hanlon-cassandra nodetool info
+#      register: result
+#      until: result.rc == 0
+#      retries: 3
+#      delay: 10
+
+    - name: Remove hanlon client config file
+      file:
+        path: "{{ hanlon_resource }}/cli/config/hanlon_client.conf"
+        state: absent
+
+    - name: Start Hanlon Server Container
+      docker:
+        docker_api_version: "{{ docker_api_version }}"
+        name: hanlon-server
+        image: cscdock/hanlon
+        pull: always
+        state: started
+        ports: 8026:8026
+#        links: hanlon-cassandra:cassandra
+        links: hanlon-mongo:mongo
+        privileged: true
+        volumes:
+          - "{{ hanlon_resource }}/image:/home/hanlon/image"
+          - "{{ hanlon_resource }}/cli/config:/home/hanlon/cli/config"
+        env:
+          DOCKER_HOST: "{{ ansible_default_ipv4.address }}"
+          HANLON_SUBNETS: "{{ hanlon_subnets }}"
+# Needed for Cassandra
+#          PERSIST_MODE: "@cassandra"
+#          REPL_STRATEGY: "SimpleStrategy"
+#          REPL_FACTOR: "1"
+
+    - name: Wait for Hanlon Server to start
+      tags: ipxe_wait
+      uri: url=http://{{ ansible_default_ipv4.address }}:8026/hanlon/api/v1/config/ipxe return_content=yes
+      register: return
+      until: (return.content.find("#!ipxe") != -1) and (return.content is defined)
+
+    - name: Start TFTP Server Container
+      docker:
+        docker_api_version: "{{ docker_api_version }}"
+        name: hanlon-atftpd
+        image: cscdock/atftpd
+        pull: always
+        state: started
+        ports: 69:69/udp
+        links: hanlon-server:hanlon


### PR DESCRIPTION
These were all kragle related items that were in wiley
- site_discovery group_vars
- hanlon modules
- dhcp server role
- site_docker.yml
- site_discovery.yml

RESULTS:

 ansible-playbook ./ansible/site_docker.ymlPLAY [Start Hanlon Docker Environment] 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [Ansible Docker Requirements] ******************************************* 
changed: [localhost] => (item=six==1.4.1)
changed: [localhost] => (item=docker-py==1.1.0)
changed: [localhost] => (item=requests==2.7.0)

TASK: [Clean up existing containers] ****************************************** 
changed: [localhost] => (item={'image': 'mongo', 'name': 'hanlon-mongo'})
changed: [localhost] => (item={'image': 'cscdock/hanlon', 'name': 'hanlon-server'})
changed: [localhost] => (item={'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'})

TASK: [Start Mongo Container] ************************************************* 
changed: [localhost]

TASK: [Remove hanlon client config file] ************************************** 
ok: [localhost]

TASK: [Start Hanlon Server Container] ***************************************** 
changed: [localhost]

TASK: [Wait for Hanlon Server to start] *************************************** 
ok: [localhost]

TASK: [Start TFTP Server Container] ******************************************* 
changed: [localhost]

PLAY RECAP ******************************************************************** 
localhost                  : ok=8    changed=5    unreachable=0    failed=0   

