### PR TITLE
Correcting file mode for ssh/config

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -45,7 +45,7 @@
   copy:
     src: config
     dest: /root/.ssh/config
-    mode: 600
+    mode: 0600
 
 - name: disable firewalld
   service:

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -8,7 +8,7 @@
   template:
     src: dhcpd.conf.j2
     dest: /etc/dhcp/dhcpd.conf
-    mode: 644
+    mode: 0644
   notify:
   - restart dhcpd
 


### PR DESCRIPTION
The task for copying the ssh/config file was improperly setting the file mode once it was copied.  This is noted in the ansible copy module docs that the mode is octal and leaving off the leading '0' can have unexpected results.
http://docs.ansible.com/ansible/copy_module.html

Current behavior (see "mode": "01130"):
```bash
TASK: [base | copy .ssh/config] ***********************************************
ok: [localhost] => {"changed": false, "checksum": "d2affc93ee309978d9bb9f9367d84e591c27124a", "dest": "/root/.ssh/config", "gid": 0, "group": "root", "mode": "01130", "owner": "root", "path": "/root/.ssh/config", "secontext": "system_u:object_r:ssh_home_t:s0", "size": 86, "state": "file", "uid": 0}
```

Corrected behavior:
```bash
TASK: [base | copy .ssh/config] ***********************************************
changed: [localhost] => {"changed": true, "checksum": "d2affc93ee309978d9bb9f9367d84e591c27124a", "dest": "/root/.ssh/config", "gid": 0, "group": "root", "mode": "0600", "owner": "root", "path": "/root/.ssh/config", "secontext": "system_u:object_r:ssh_home_t:s0", "size": 86, "state": "file", "uid": 0}
```