### PR TITLE
Adding tasks to add pub key to auth users

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -47,6 +47,15 @@
     dest: /root/.ssh/config
     mode: 600
 
+- name: Retrieve deployment node public key
+  shell: cat /root/.ssh/id_rsa.pub
+  register: pub_key
+
+- name: Add deployment node SSH key to node authorized users
+  authorized_key:
+    user: root
+    key: "{{ pub_key.stdout }}"
+
 - name: disable firewalld
   service:
     name: firewalld


### PR DESCRIPTION
The pub key for the deployment node is not in the ssh authorized users.  This causes some tasks in other projects to fail when trying to connect to the deployment node.  This PR adds the key.

Testing:
```bash
TASK: [base | Retrieve deployment node public key] ****************************
changed: [localhost]

TASK: [base | Add deployment node SSH key to node authorized users] ***********
changed: [localhost]
```