### PR TITLE
Updating Docker configuration for Ansible

### DIFF
--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -9,15 +9,6 @@
     docker_api_version: 1.18
 
   tasks:
-    - name: Ansible Docker Requirements
-      pip:
-        name: "{{ item }}"
-        extra_args: "-I"
-      with_items:
-      - six==1.4.1
-      - docker-py==1.1.0
-      - requests==2.7.0
-
     - name: Clean up existing containers
       docker:
         docker_api_version: "{{ docker_api_version }}"
@@ -35,7 +26,7 @@
         docker_api_version: "{{ docker_api_version }}"
         name: hanlon-mongo
         image: mongo
-        pull: always
+        pull: missing
         state: started
         command: mongod --smallfiles
         volumes: "{{ hanlon_resource }}/data/db:/data/db"
@@ -45,7 +36,7 @@
 #        docker_api_version: "{{ docker_api_version }}"
 #        name: hanlon-cassandra
 #        image: tobert/cassandra
-#        pull: always
+#        pull: missing
 #        state: started
 #        volumes: "{{ hanlon_resource }}/data/db:/data"
 #
@@ -66,7 +57,7 @@
         docker_api_version: "{{ docker_api_version }}"
         name: hanlon-server
         image: cscdock/hanlon
-        pull: always
+        pull: missing
         state: started
         ports: 8026:8026
 #        links: hanlon-cassandra:cassandra
@@ -94,7 +85,7 @@
         docker_api_version: "{{ docker_api_version }}"
         name: hanlon-atftpd
         image: cscdock/atftpd
-        pull: always
+        pull: missing
         state: started
         ports: 69:69/udp
         links: hanlon-server:hanlon


### PR DESCRIPTION
These changes are to support running kragle in an offline mode.

The site_docker.yml would update some pip dependencies required for the
docker module to function properly. These dependencies are no longer
required and have been removed.

Additionally, the docker module tasks have been updated to pull only when
the required docker image is missing, preventing the system from trying
to update the image every time.  With these changes, the site_docker.yml
playbook can be run while kragle is 'offline'.

site_docker.yml Offline Testing:
```
[root@localhost kragle]# ansible-playbook ./ansible/site_docker.yml

PLAY [Start Hanlon Docker Environment] ****************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Clean up existing containers] ******************************************
ok: [localhost] => (item={'image': 'mongo', 'name': 'hanlon-mongo'})
ok: [localhost] => (item={'image': 'cscdock/hanlon', 'name': 'hanlon-server'})
ok: [localhost] => (item={'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'})

TASK: [Start Mongo Container] *************************************************
changed: [localhost]

TASK: [Remove hanlon client config file] **************************************
changed: [localhost]

TASK: [Start Hanlon Server Container] *****************************************
changed: [localhost]

TASK: [Wait for Hanlon Server to start] ***************************************
ok: [localhost]

TASK: [Start TFTP Server Container] *******************************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=7    changed=4    unreachable=0    failed=0
```
