### PR TITLE
kragle - added offline variables

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,4 +1,9 @@
 ---
+#Offline Kragle vars
+offline: true
+py_offline_pkgs: /mnt/sdb/packages/
+hnl_offline_mk_source: /root/ISO/
+
 #Kragle common vars
 auto_deploy_node: 172.17.16.10
 hanlon_base_url: http://{{ auto_deploy_node }}:8026/hanlon/api/v1/


### PR DESCRIPTION
Added the following vars for offline Kragle build

+offline: true
+py_offline_pkgs: /mnt/sdb/packages/
+hnl_offline_mk_source: /root/ISO/