### PR TITLE
Kragle - Site_discovery

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,4 +1,9 @@
 ---
+#Offline Kragle vars
+offline: true
+py_offline_pkgs: /mnt/sdb/packages/
+hnl_offline_mk_source: /root/ISO/
+
 #Kragle common vars
 auto_deploy_node: 172.17.16.10
 hanlon_base_url: http://{{ auto_deploy_node }}:8026/hanlon/api/v1/

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -27,6 +27,14 @@
     name: docker-py
     state: present
     extra_args: "--upgrade"
+    when: not offline
+
+- name: install docker-py when offline
+  pip:
+    name: docker-py
+    state: present
+    extra_args: "--index-url=file://{{ py_offline_pkgs }}simple/"
+  when: offline
 
 - name: create .ssh directory
   file:
@@ -105,6 +113,7 @@
     method: GET
   with_items: git_repos
   register: tags
+  when: not offline
 
 - name: clone repos from git
   git:
@@ -114,3 +123,4 @@
     version: "{{ item.json[0].name }}"
   ignore_errors: true
   with_items: tags.results
+  when: not offline

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -24,7 +24,8 @@
       copy:
         src: "{{ hnl_offline_mk_source }}{{ hnl_mk_image }}"
         dest: "{{ hnl_mk_local_path }}"
-
+      when: offline
+      
     - name: Add a Microkernel Image to Hanlon
       hanlon_image:
         base_url: "{{ hanlon_base_url }}"

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -18,7 +18,12 @@
       get_url:
         url: "{{ hnl_mk_source }}{{ hnl_mk_image }}"
         dest: "{{ hnl_mk_local_path }}"
-      when: not hnl_mk.stat.exists
+      when: not hnl_mk.stat.exists and not offline
+
+    - name: Copy Hanlon Microkernel to /opt/hanlon/image
+      copy:
+        src: "{{ hnl_offline_mk_source }}{{ hnl_mk_image }}"
+        dest: "{{ hnl_mk_local_path }}"
 
     - name: Add a Microkernel Image to Hanlon
       hanlon_image:

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -21,6 +21,14 @@
         - { name: hanlon-server, image: cscdock/hanlon }
         - { name: hanlon-atftpd, image: cscdock/atftpd }
 
+    - name: Load Mongo, Hanlon and Atftpd Containers Offline
+      shell: docker load --input /root/docker/{{ item }}
+      with_items:
+        - mongo.tar
+        - cscdock_hanlon.tar
+        - cscdock_atftpd.tar
+      when: offline
+
     - name: Start Mongo Container
       docker:
         docker_api_version: "{{ docker_api_version }}"


### PR DESCRIPTION
Added to copy the Hanlon microkernel when offline


[root@nuc ansible]# ansible-playbook site_discovery.yml 

PLAY [Configure deployment node for site discovery] *************************** 

GATHERING FACTS *************************************************************** 
ok: [localhost]

TASK: [dhcp-server | install dhcp server package] ***************************** 
ok: [localhost]

TASK: [dhcp-server | setup dhcpd.conf] **************************************** 
ok: [localhost]

TASK: [dhcp-server | enable dhcpd service] ************************************ 
ok: [localhost]

TASK: [Check for local copy of Hanlon Microkernel] **************************** 
ok: [localhost]

TASK: [Download Hanlon Microkernel] ******************************************* 
skipping: [localhost]

TASK: [Copy Hanlon Microkernel to /opt/hanlon/image] ************************** 
ok: [localhost]

TASK: [Add a Microkernel Image to Hanlon] ************************************* 
ok: [localhost]

TASK: [Add a Discover Only Model to Hanlon] *********************************** 
ok: [localhost]

TASK: [Add a Discover Only Policy to Hanlon] ********************************** 
ok: [localhost]

PLAY RECAP ******************************************************************** 
localhost                  : ok=9    changed=0    unreachable=0    failed=0