### PR TITLE
Ipxe changes

### DIFF
--- a/ansible/roles/dhcp-server/defaults/main.yml
+++ b/ansible/roles/dhcp-server/defaults/main.yml
@@ -1,2 +1,13 @@
 ---
 packer: false
+
+#options for EFI 32-bit - ipxe-x86.efi or snponly-x86.efi
+ipxe_efi_x86_rom: "ipxe-x86.efi"
+
+#options for EFI 64-bit - ipxe-x64.efi or snponly-x64.efi
+ipxe_efi_x64_rom: "ipxe-x64.efi"
+
+#options for legacy BIOS x86 mode - undionly.kpxe or ipxe.pxe
+ipxe_legacy_rom: "ipxe.pxe"
+
+hanlon_ipxe: "hanlon.ipxe"

--- a/ansible/roles/dhcp-server/files/ipxe-option-space.conf
+++ b/ansible/roles/dhcp-server/files/ipxe-option-space.conf
@@ -1,0 +1,49 @@
+# Declare the iPXE/gPXE/Etherboot option space
+option space ipxe;
+option ipxe-encap-opts code 175 = encapsulate ipxe;
+
+# iPXE options, can be set in DHCP response packet
+option ipxe.priority         code   1 = signed integer 8;
+option ipxe.keep-san         code   8 = unsigned integer 8;
+option ipxe.skip-san-boot    code   9 = unsigned integer 8;
+option ipxe.syslogs          code  85 = string;
+option ipxe.cert             code  91 = string;
+option ipxe.privkey          code  92 = string;
+option ipxe.crosscert        code  93 = string;
+option ipxe.no-pxedhcp       code 176 = unsigned integer 8;
+option ipxe.bus-id           code 177 = string;
+option ipxe.bios-drive       code 189 = unsigned integer 8;
+option ipxe.username         code 190 = string;
+option ipxe.password         code 191 = string;
+option ipxe.reverse-username code 192 = string;
+option ipxe.reverse-password code 193 = string;
+option ipxe.version          code 235 = string;
+option iscsi-initiator-iqn   code 203 = string;
+
+# iPXE feature flags, set in DHCP request packet
+option ipxe.pxeext    code 16 = unsigned integer 8;
+option ipxe.iscsi     code 17 = unsigned integer 8;
+option ipxe.aoe       code 18 = unsigned integer 8;
+option ipxe.http      code 19 = unsigned integer 8;
+option ipxe.https     code 20 = unsigned integer 8;
+option ipxe.tftp      code 21 = unsigned integer 8;
+option ipxe.ftp       code 22 = unsigned integer 8;
+option ipxe.dns       code 23 = unsigned integer 8;
+option ipxe.bzimage   code 24 = unsigned integer 8;
+option ipxe.multiboot code 25 = unsigned integer 8;
+option ipxe.slam      code 26 = unsigned integer 8;
+option ipxe.srp       code 27 = unsigned integer 8;
+option ipxe.nbi       code 32 = unsigned integer 8;
+option ipxe.pxe       code 33 = unsigned integer 8;
+option ipxe.elf       code 34 = unsigned integer 8;
+option ipxe.comboot   code 35 = unsigned integer 8;
+option ipxe.efi       code 36 = unsigned integer 8;
+option ipxe.fcoe      code 37 = unsigned integer 8;
+option ipxe.vlan      code 38 = unsigned integer 8;
+option ipxe.menu      code 39 = unsigned integer 8;
+option ipxe.sdi       code 40 = unsigned integer 8;
+option ipxe.nfs       code 41 = unsigned integer 8;
+
+# Other useful general options
+# http://www.ietf.org/assignments/dhcpv6-parameters/dhcpv6-parameters.txt
+option arch code 93 = unsigned integer 16;

--- a/ansible/roles/dhcp-server/tasks/main.yml
+++ b/ansible/roles/dhcp-server/tasks/main.yml
@@ -4,10 +4,26 @@
     name: dhcp
     state: present
 
-- name: setup dhcpd.conf
+- name: Configure dhcpd.conf
   template:
     src: dhcpd.conf.j2
     dest: /etc/dhcp/dhcpd.conf
+    mode: 0644
+  notify:
+  - restart dhcpd
+
+- name: Configure ipxe.conf
+  template:
+    src: ipxe.conf.j2
+    dest: /etc/dhcp/ipxe.conf
+    mode: 0644
+  notify:
+  - restart dhcpd
+
+- name: Copy ipxe-option-space.conf
+  copy:
+    src: ipxe-option-space.conf
+    dest: /etc/dhcp/ipxe-option-space.conf
     mode: 0644
   notify:
   - restart dhcpd

--- a/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
+++ b/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
@@ -1,6 +1,9 @@
 # dhcpd.conf
 #
 
+include "/etc/dhcp/ipxe-option-space.conf";
+
+
 default-lease-time 600;
 max-lease-time 7200;
 
@@ -22,9 +25,5 @@ subnet {{ pxe_subnet_name }} netmask {{ pxe_subnet_mask }} {
     option hanlon_port          8026;
     option hanlon_base_uri      "/hanlon/api/v1";
 
-    if exists user-class and option user-class = "iPXE" {
-        filename "hanlon.ipxe";
-    } else {
-        filename "undionly.kpxe";
-    }
+    include "/etc/dhcp/ipxe.conf";
 }

--- a/ansible/roles/dhcp-server/templates/ipxe.conf.j2
+++ b/ansible/roles/dhcp-server/templates/ipxe.conf.j2
@@ -1,0 +1,49 @@
+allow bootp;
+allow booting;
+
+# Disable ProxyDHCP, we're in control of the primary DHCP server
+option ipxe.no-pxedhcp 1;
+
+# ipxe.comboot is required for ESXi and lets make sure our ROM has it enabled before proceeding
+#
+if exists ipxe.http and exists ipxe.menu and ( (exists ipxe.pxe and exists ipxe.comboot) or (exists ipxe.efi) ) {
+    filename "{{ hanlon_ipxe }}"; 
+}
+elsif exists user-class and option user-class = "iPXE" {
+    # We're already using iPXE, but not a feature-full version,
+    # and possibly an out-of-date version from ROM, so load a more
+    # complete version with native drivers
+    # Allow both legacy BIOS and EFI architectures
+    if option arch = 00:06 {
+        filename "{{ ipxe_efi_x86_rom }}";
+    } elsif option arch = 00:07 {
+        filename "{{ ipxe_efi_x64_rom }}";
+    } elsif option arch = 00:00 {
+        filename "{{ ipxe_legacy_rom }}";
+    }
+}
+elsif option arch = 00:06 {
+    # EFI 32-bit
+    # I like to use iPXE-provided drivers, so therefore give ipxe.efi
+    # to all non-iPXE clients, use snponly.efi if you have unsupported
+    # or misbehaving NICs
+    filename "{{ ipxe_efi_x86_rom }}";
+}
+elsif option arch = 00:07 {
+    # EFI 64-bit
+    # I like to use iPXE-provided drivers, so therefore give ipxe.efi
+    # to all non-iPXE clients, use snponly.efi if you have unsupported
+    # or misbehaving NICs
+    filename "{{ ipxe_efi_x64_rom }}";
+}
+elsif option arch = 00:00 {
+    # Legacy BIOS x86 mode
+    # I like to use iPXE-provided drivers, so therefore give ipxe.pxe
+    # to all non-iPXE clients, use undionly.kpxe if you have unsupported
+    # or misbehaving NICs
+    filename "{{ ipxe_legacy_rom }}";
+    #filename "undionly.kpxe";
+}
+else {
+    # Unsupported client architecture type, so do nothing
+}


### PR DESCRIPTION
Used `packer: true` because my home lab does not have the same subnet as Austin lab.  Will add further testing.

```
➜  ansible git:(06dfcc1) ✗ ansible-playbook -e '{"packer": true}' site_discovery.yml

PLAY [Configure deployment node for site discovery] ***************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [dhcp-server | install dhcp server package] *****************************
ok: [localhost]

TASK: [dhcp-server | Configure dhcpd.conf] ************************************
ok: [localhost]

TASK: [dhcp-server | Configure ipxe.conf] *************************************
ok: [localhost]

TASK: [dhcp-server | Copy ipxe-option-space.conf] *****************************
ok: [localhost]

TASK: [dhcp-server | enable dhcpd service] ************************************
skipping: [localhost]

TASK: [Check for local copy of Hanlon Microkernel] ****************************
ok: [localhost]

TASK: [Download Hanlon Microkernel] *******************************************
changed: [localhost]

TASK: [Copy Hanlon Microkernel to /opt/hanlon/image] **************************
skipping: [localhost]

TASK: [Add a Microkernel Image to Hanlon] *************************************
skipping: [localhost]

TASK: [Add a Discover Only Model to Hanlon] ***********************************
skipping: [localhost]

TASK: [Add a Discover Only Policy to Hanlon] **********************************
skipping: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=7    changed=1    unreachable=0    failed=0
```