### PR TITLE
Cleaning up unused variables

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -25,8 +25,6 @@ hnl_mk_local_path: /opt/hanlon/image/
 hnl_mk_path: /home/hanlon/image/{{ hnl_mk_image }}
 
 git_repos:
-#  - { name: "wiley", repo: "git://github.com/csc/wiley", tag: "https://api.github.com/repos/csc/wiley/tags" }
   - { name: "slimer", repo: "git://github.com/csc/slimer", tag: "https://api.github.com/repos/csc/slimer/tags" }
   - { name: "kragle", repo: "git://github.com/csc/kragle", tag: "https://api.github.com/repos/csc/kragle/tags" }
   - { name: "ansible-scaleio", repo: "git://github.com/csc/ansible-scaleio", tag: "https://api.github.com/repos/csc/ansible-scaleio/tags" }
-


### PR DESCRIPTION
NGA-420 - Cleaning up unused variables in the kragle project.

Most everything in kragle's inventory appears to be referenced except for the wiley repo. Cleared that out.