### PR TITLE
added `python-netaddr` to yum install list

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -18,6 +18,7 @@
     - ntp
     - python-passlib
     - python-pip
+    - python-netaddr
     - sshpass
     - vim
     - wget


### PR DESCRIPTION
Added ` python-netaddr` to the install list as it is needed for the demo.yml ansible scripts