### PR TITLE
Separarting EPEL packages from RHN packages

### DIFF
--- a/ansible/files/epel_rpm_packages.txt
+++ b/ansible/files/epel_rpm_packages.txt
@@ -1,0 +1,4 @@
+ansible
+python-pip
+python-xvfbwrapper
+sshpass

--- a/ansible/files/rhn_rpm_packages.txt
+++ b/ansible/files/rhn_rpm_packages.txt
@@ -1,4 +1,3 @@
-ansible
 bind-utils
 bridge-utils
 ceph-common
@@ -78,14 +77,11 @@ python-nova
 python-novaclient
 python-openstackclient
 python-passlib
-python-pip
 python-swiftclient
-python-xvfbwrapper
 rabbitmq-server
 resource-agents
 rsync
 sos
-sshpass
 tcpdump
 traceroute
 unzip

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -16,9 +16,9 @@ iso_path: "{{ resources_base_path }}/ISO/"
 packages_path: "{{ resources_base_path }}/packages/"
 projects_base_path: "{{ autodeploy_base_path }}/projects"
 resources_base_path: "{{ autodeploy_base_path }}/resources"
-rpm_file: rpm_packages.txt
+epel_rpm_file: "{{ projects_base_path }}/kragle/ansible/files/epel_rpm_packages.txt"
+rhn_rpm_file: "{{ projects_base_path }}/kragle/ansible/files/rhn_rpm_packages.txt"
 rpm_path: "{{ resources_base_path }}/rpms/"
-rpm_list: "{{ projects_base_path }}/kragle/ansible/files/{{ rpm_file }}"
 scaleio_path: "{{ resources_base_path }}/scaleio/"
 
 # Autodeploy site_discovery vars:
@@ -65,10 +65,10 @@ autodeploy_support_pkgs:
   - dhcp
   - docker
   - firefox
+  - genisoimage
   - httpd
   - ipmitool
   - iptables-services
-  - mkisofs
   - ntp
   - python-ipaddr
   - python-passlib

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -102,8 +102,20 @@
         dest: "{{ iso_path }}"
       tags: iso
 
+    - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms
+      shell: repotrack $(cat {{ epel_rpm_file }}) -p {{ rpm_path }}
+      when: offline
+      tags: repo
+
     - name: Download the Red Hat RPMs to /opt/autodeploy/resources/rpms
-      shell: repotrack $(cat {{ rpm_list }}) -p {{ rpm_path }}
+      shell:
+        repotrack $(cat {{ rhn_rpm_file }}) -p {{ rpm_path }}
+        -r rhel-7-server-extras-rpms
+        -r rhel-7-server-openstack-6.0-rpms
+        -r rhel-7-server-optional-rpms
+        -r rhel-7-server-rpms
+        -r rhel-ha-for-rhel-7-server-rpms
+        -r rhel-server-rhscl-7-rpms
       when: offline
       tags: repo
 


### PR DESCRIPTION
There are conflicting package versions between EPEL and RHN repos where packages from RHN are required.  These changes split the download of packages to ensure the correct versions are downloaded.

The required version of mongodb from RHN is: mongodb-2.6.5-2.el7ost.x86_64

Testing:

```
[root@staging ansible]# ansible-playbook -v stage_resources.yml --tags=pkgs,repo
...
PLAY RECAP ********************************************************************
localhost                  : ok=6    changed=3    unreachable=0    failed=0
```

Confirming the right version of mongo was downloaded:
```
[root@staging ansible]# ls -l /opt/autodeploy/resources/rpms/mong*
-rw-r--r--. 1 root root 59699728 Jan 19  2015 /opt/autodeploy/resources/rpms/mongodb-2.6.5-2.el7ost.x86_64.rpm
-rw-r--r--. 1 root root  9130984 Jan 19  2015 /opt/autodeploy/resources/rpms/mongodb-server-2.6.5-2.el7ost.x86_64.rpm
```