### PR TITLE
Adding python-netaddr

### DIFF
--- a/ansible/files/rhn_rpm_packages.txt
+++ b/ansible/files/rhn_rpm_packages.txt
@@ -70,9 +70,9 @@ python-cinder
 python-cinderclient
 python-glanceclient
 python-heatclient
-python-ipaddr
 python-keystonemiddleware
 python-memcached
+python-netaddr
 python-nova
 python-novaclient
 python-openstackclient

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -70,7 +70,7 @@ autodeploy_support_pkgs:
   - ipmitool
   - iptables-services
   - ntp
-  - python-ipaddr
+  - python-netaddr
   - python-passlib
   - python-pip
   - python-xvfbwrapper


### PR DESCRIPTION
python-netaddr is required in place of python-ipaddr.  The package has
been added to the RHN package list as well as the required support
packages for the autodeploy node.  This library is required for the
slimer demo role jinja2 filters which are run on the autodeploynode.