### PR TITLE
Fixed logic error in base role in kragle.

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -93,7 +93,7 @@
   service:
     name: "{{ item }}"
     enabled: yes
-    state: started
+    state: restarted
   with_items:
     - iptables
     - ntpd


### PR DESCRIPTION
Fixed issue where 
```
TASK: [Start Hanlon Server Container] *****************************************
failed: [localhost] => {"changed": true, "failed": true}
msg: Docker API Error: Cannot start container 53077093e449856e519e39932238ae28bc5c9c4a3ee783e72689e4df8dd9e2e8: iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 8026 -j DNAT --to-destination 172.17.0.2:8026 ! -i docker0: iptables: No chain/target/match by that name.
 (exit status 1)
```

now:
```
TASK: [Start Hanlon Server Container] *****************************************
changed: [localhost]
```