### PR TITLE
Updates for pinning docker package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ sudo: false
 
 install:
   # Install Ansible.
-  - pip install ansible
+  - pip install ansible==1.9.4
 
 script:
-  - cd ansible && python travis_parse_yaml.py main.yml site_discovery.yml site_docker.yml
+  - cd ansible && python travis_parse_yaml.py
+      initial_stage.yml
+      main.yml
+      site_discovery.yml
+      site_docker.yml
+      stage_resources.yml

--- a/ansible/files/pip-requirements.txt
+++ b/ansible/files/pip-requirements.txt
@@ -1,0 +1,10 @@
+## docker-py and dependencies
+docker-py==1.4.0
+requests==2.8.1
+six==1.10.0
+websocket-client==0.34.0
+backports.ssl-match-hostname==3.4.0.2
+
+## Other requirements
+pip2pi==0.6.8
+selenium==2.48.0

--- a/ansible/files/rhn_rpm_packages.txt
+++ b/ansible/files/rhn_rpm_packages.txt
@@ -4,7 +4,7 @@ bridge-utils
 ceph-common
 createrepo
 dhcp
-docker
+docker-1.7.1
 fence-agents-all
 firefox
 genisoimage

--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -63,7 +63,7 @@ usb_resources_path: "{{ usb_hdd }}/autodeploy/resources"
 autodeploy_support_pkgs:
   - createrepo
   - dhcp
-  - docker
+  - docker-1.7.1
   - firefox
   - genisoimage
   - httpd
@@ -80,11 +80,6 @@ autodeploy_support_pkgs:
   - wget
   - xorg-x11-server-Xvfb
   - yum-utils
-
-pip_pkgs:
-  - docker-py
-  - pip2pi
-  - selenium
 
 source_projects:
   - ansible-scaleio

--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -1,29 +1,22 @@
 ---
 # The base role will do the initial preparation of the autodeploynode.
 
-- name: Install package updates
-  yum:
-    name: "*"
-    state: latest
-  ignore_errors: true
-  when: not offline
-
 - name: Install required support packages
   yum:
     pkg: "{{ item }}"
     state: present
   with_items: autodeploy_support_pkgs
 
-- name: Install docker-py with pip
+- name: Install required pip-based support packages (Online)
   pip:
-    name: docker-py
+    requirements: "{{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt"
     state: present
     extra_args: "--upgrade"
   when: not offline
 
-- name: Install docker-py with pip when offline
+- name: Install required pip-based support packages (Offline)
   pip:
-    name: docker-py
+    requirements: "{{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt"
     state: present
     extra_args: "--index-url=file://{{ packages_path }}simple/"
   when: offline
@@ -99,7 +92,7 @@
     - ntpd
     - docker
 
-- name: Get latest tagged version of Git repos
+- name: Get latest tagged version of Git repos (Online)
   uri:
     url: "{{ item.tag }}"
     method: GET
@@ -107,7 +100,7 @@
   register: tags
   when: not offline
 
-- name: Clone source Git repos
+- name: Clone source Git repos (Online)
   git:
     repo: "{{ item.item.repo }}"
     dest: "{{ projects_base_path }}/{{ item.item.name }}"

--- a/ansible/roles/createrepo/tasks/main.yml
+++ b/ansible/roles/createrepo/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: Create offline HTTP repository
   command: createrepo "/var/www/html/repo"
 
-- name: Repo file to provide to hosts
+- name: Create repo file to provide to hosts
   template:
     src: offline.repo.j2
     dest: "/var/www/html/repo/offline.repo"

--- a/ansible/roles/prep-projects/tasks/scaleio.yml
+++ b/ansible/roles/prep-projects/tasks/scaleio.yml
@@ -7,7 +7,7 @@
     path: "{{ scaleio_path }}/{{ scaleio_source_zip }}"
   register: scaleio_zip
 
-- name: Download ScaleIO files for ansible-scaleio project
+- name: Download ScaleIO files for ansible-scaleio project (Online)
   get_url:
     url:  "{{ scaleio_source_url }}"
     dest: "{{ scaleio_path }}"

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -15,13 +15,13 @@
         path: "{{ hnl_mk_local_path }}{{ hnl_mk_image }}"
       register: hnl_mk
 
-    - name: Download Hanlon Microkernel
+    - name: Download Hanlon Microkernel (Online)
       get_url:
         url: "{{ hnl_mk_source }}{{ hnl_mk_image }}"
         dest: "{{ hnl_mk_local_path }}"
       when: not hnl_mk.stat.exists and not offline
 
-    - name: Copy Hanlon Microkernel to /opt/hanlon/image
+    - name: Copy Hanlon Microkernel to /opt/hanlon/image (Offline)
       copy:
         src: "{{ iso_path }}{{ hnl_mk_image }}"
         dest: "{{ hnl_mk_local_path }}"

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -21,7 +21,7 @@
         - { name: hanlon-server, image: cscdock/hanlon }
         - { name: hanlon-atftpd, image: cscdock/atftpd }
 
-    - name: Load Mongo, Hanlon and Atftpd Containers Offline
+    - name: Load Mongo, Hanlon and Atftpd Containers (Offline)
       command: docker load --input "{{ docker_path }}/{{ item }}"
       with_items: docker_files
       when: offline

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -17,10 +17,9 @@
 
     - name: Install required pip-based support packages
       pip:
-        name: "{{ item }}"
+        requirements: "{{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt"
         state: present
         extra_args: "--upgrade"
-      with_items: pip_pkgs
       tags: pkgs
 
     - name: Create the staging directories in /opt/autodeploy
@@ -102,12 +101,12 @@
         dest: "{{ iso_path }}"
       tags: iso
 
-    - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms
+    - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms (Offline)
       shell: repotrack $(cat {{ epel_rpm_file }}) -p {{ rpm_path }}
       when: offline
       tags: repo
 
-    - name: Download the Red Hat RPMs to /opt/autodeploy/resources/rpms
+    - name: Download the Red Hat RPMs to /opt/autodeploy/resources/rpms (Offline)
       shell:
         repotrack $(cat {{ rhn_rpm_file }}) -p {{ rpm_path }}
         -r rhel-7-server-extras-rpms
@@ -119,17 +118,17 @@
       when: offline
       tags: repo
 
-    - name: Create the local offline repository in /opt/autodeploy/resources/rpms
+    - name: Create the local repository in /opt/autodeploy/resources/rpms (Offline)
       command: createrepo "{{ rpm_path }}"
       when: offline
       tags: repo
 
-    - name: Mirror docker-py and its dependencies to /opt/autodeploy/resources/packages
-      command: pip2tgz "{{ packages_path }}" docker-py
+    - name: Mirror pip dependencies to /opt/autodeploy/resources/packages (Offline)
+      command: pip2tgz {{ packages_path }} -r {{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt
       when: offline
       tags: docker
 
-    - name: Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages
+    - name: Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages (Offline)
       command: dir2pi "{{ packages_path }}"
       when: offline
       tags: docker
@@ -155,7 +154,7 @@
         - { name: hanlon-atftpd, image: cscdock/atftpd }
       tags: docker
 
-    - name: Save docker container images to /opt/autodeploy/resources/docker
+    - name: Save docker container images to /opt/autodeploy/resources/docker (Offline)
       shell: docker save docker.io/"{{ item.image }}" > "{{ docker_path }}/{{ item.tar_file }}"
       with_items:
         - { image: cscdock/hanlon, tar_file: cscdock_hanlon.tar }
@@ -170,15 +169,15 @@
         dest: "{{ scaleio_path }}"
       tags: scaleio
 
-    - name: Copy the downloaded projects to the usb drive
+    - name: Copy the downloaded projects to the usb drive (Offline)
       copy:
         src: "{{ projects_base_path }}/{{ item }}"
         dest: "{{ usb_projects_path }}"
       with_items: source_projects
-      when : offline
+      when: offline
       tags: copy
 
-    - name: Copy the downloaded resources to the usb drive
+    - name: Copy the downloaded resources to the usb drive (Offline)
       copy:
         src: "{{ resources_base_path }}/{{ item }}"
         dest: "{{ usb_resources_path }}"


### PR DESCRIPTION
With recent changes in upstream docker RPM packages as well as docker-py python modules, several dependencies have broken Ansible functionality. These changes pin docker to version 1.7.1 and docker-py to 1.4 for functionality with Ansible 1.9.4.

Testing was performed in virtual machines on my local laptop.

Testing (Offline):
Staging Node (10.0.10.5)
```
subscription-manager register --username='xxxx'  --password='xxxx'
subscription-manager attach --pool=xxxx
subscription-manager repos --disable=*
subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-openstack-6.0-rpms --enable=rhel-server-rhscl-7-rpms --enable=rhel-ha-for-rhel-7-server-rpms
yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
yum -y install git ansible-1.9.4 wget
mkdir /mnt/sdb1
wget https://raw.githubusercontent.com/csc/kragle/master/ansible/initial_stage.yml
ansible-playbook initial_stage.yml
cd /opt/autodeploy/projects/kragle/ansible
git remote add mtnbikenc https://github.com/mtnbikenc/kragle
git fetch mtnbikenc
git checkout mtnbikenc/530-docker-deps
vi inventory/group_vars/all.yml
  <made all required changes to file>
ansible-playbook stage_resources.yml
scp -rp /mnt/sdb1/autodeploy 'root@10.0.10.10:/opt/autodeploy'
```
Autodeploy Node (10.0.10.10)
```
cp /opt/autodeploy/projects/kragle/ansible/files/local.repo /etc/yum.repos.d/
yum -y install git ansible-1.9.4
cd /opt/autodeploy/projects/kragle/ansible
ansible-playbook main.yml
ansible-playbook site_docker.yml
ansible-playbook site_discovery.yml
```

Testing Online:
Autodeploy Node (10.0.10.10)
```
subscription-manager register --username='xxxx'  --password='xxxx'
subscription-manager attach --pool=xxxx
subscription-manager repos --disable=*
subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-openstack-6.0-rpms --enable=rhel-server-rhscl-7-rpms --enable=rhel-ha-for-rhel-7-server-rpms
yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
yum -y install git ansible-1.9.4 wget
wget https://raw.githubusercontent.com/csc/kragle/master/ansible/initial_stage.yml
ansible-playbook initial_stage.yml
cd /opt/autodeploy/projects/kragle/ansible
git remote add mtnbikenc https://github.com/mtnbikenc/kragle
git fetch mtnbikenc
git checkout mtnbikenc/530-docker-deps
vi inventory/group_vars/all.yml
  <made all required changes to file>
ansible-playbook stage_resources.yml
ansible-playbook main.yml
ansible-playbook site_docker.yml
ansible-playbook site_discovery.yml
```