### PR TITLE
kragle - idempotence

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -11,6 +11,7 @@ autodeploy_base_path: /opt/autodeploy
 dns1: x.x.x.x
 docker_api_version: 1.18
 docker_path: "{{ resources_base_path }}/docker/"
+docker_py_zip: docker-py-1.4.0.tar.gz
 hanlon_base_url: http://{{ auto_deploy_node }}:8026/hanlon/api/v1/
 iso_path: "{{ resources_base_path }}/ISO/"
 packages_path: "{{ resources_base_path }}/packages/"
@@ -93,10 +94,10 @@ iso_files:
   - "{{ hnl_rhel_min_image }}"
   - "{{ kvm_guest_image }}"
 
-docker_files:
-  - cscdock_hanlon.tar
-  - cscdock_atftpd.tar
-  - mongo.tar
+docker_images:
+  - { name: hanlon-mongo, image: mongo, tar_file: mongo.tar }
+  - { name: hanlon-server, image: cscdock/hanlon, tar_file: cscdock_hanlon.tar }
+  - { name: hanlon-atftpd, image: cscdock/atftpd, tar_file: cscdock_atftpd.tar }
 
 resource_dirs:
   - docker

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -52,14 +52,20 @@
         password: "{{ git_pass }}"
         username_element_id: login_field
         password_element_id: password
-        download_directory: "{{ projects_base_path }}/wiley/"
+        download_directory: "{{ projects_base_path }}/{{ private_git_repo }}"
       register: download_git
       when: not (private_git.stat.exists)
       tags: git
 
+    - name: Check if private project was extracted in /opt/autodeploy/projects
+      stat:
+        path: "{{ projects_base_path }}/{{ private_git_repo }}"
+      register: extracted
+      tags: git
+
     - name: Extract the private project source files
       command: "tar -C {{ projects_base_path }}/wiley/ -xvzf {{ projects_base_path }}/wiley/{{ private_git_file}} --strip=1"
-      when: download_git.changed == true
+      when: (extracted.stat.isdir is defined and simple.stat.isdir)
       tags: git
 
     - name: Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO
@@ -201,7 +207,7 @@
       when: offline and not (item.stat.exists)
       tags: docker
 
-   - name: Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio
+    - name: Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio
       stat:
         path: "{{ scaleio_path }}/{{ scaleio_source_zip }}"
       register: scaleio_zip

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -1,8 +1,9 @@
 ---
-# This playbook will prepare the staging directories and retrieve the automation resources for the autodeploynode.
-# The resources will be staged locally in the /opt/autodeploy/projects/ and opt/autodeploy/resources/ directories.
+# This playbook will prepare the staging directories and retrieve the automation resources for the
+# autodeploynode. The resources will be staged locally in the /opt/autodeploy/projects/ and
+# opt/autodeploy/resources/ directories.
 
-- name: Prepare the staging resources
+- name: Stage DCAF automation resources on autodeploynode
   gather_facts: true
   hosts: localhost
 
@@ -52,17 +53,32 @@
         username_element_id: login_field
         password_element_id: password
         download_directory: "{{ projects_base_path }}/wiley/"
+      register: download_git
       when: not (private_git.stat.exists)
       tags: git
 
     - name: Extract the private project source files
       command: "tar -C {{ projects_base_path }}/wiley/ -xvzf {{ projects_base_path }}/wiley/{{ private_git_file}} --strip=1"
+      when: download_git.changed == true
       tags: git
+
+    - name: Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO
+      stat:
+        path: "{{ iso_path }}/{{ hnl_mk_image }}"
+      register: hnl_mk
+      tags: iso
 
     - name: Download the Hanlon microkernel image to /opt/autodeploy/resources/ISO
       get_url:
         url: "{{ hnl_mk_source }}{{ hnl_mk_image }}"
         dest: "{{ iso_path }}"
+      when: not (hnl_mk.stat.exists)
+      tags: iso
+
+    - name: Check if RHEL DVD ISO file exists in /opt/autodeploy/resources/ISO
+      stat:
+        path: "{{ iso_path }}/{{ rhel_iso_image }}"
+      register: rhel_iso
       tags: iso
 
 # There two separate selenium downloads here because the authtoken on the link will time out
@@ -75,12 +91,20 @@
         password_element_id: password
         xpath: '//*[contains(@href,"{{ rhel_iso_image }}")]'
       register: rhel_get_url
+      when: not (rhel_iso.stat.exists)
       tags: iso
 
     - name: Download the RHEL DVD ISO file to /opt/autodeploy/resources/ISO
       get_url:
         url: "{{ rhel_get_url.url }}"
         dest: "{{ iso_path }}"
+      when: not (rhel_iso.stat.exists)
+      tags: iso
+
+    - name: Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO
+      stat:
+        path: "{{ iso_path }}/{{ kvm_guest_image }}"
+      register: kvm_guest
       tags: iso
 
 # There two separate selenium downloads here because the authtoken on the link will time out
@@ -93,20 +117,22 @@
         password_element_id: password
         xpath: '//*[contains(@href,"{{ kvm_guest_image }}")]'
       register: kvm_get_url
+      when: not (kvm_guest.stat.exists)
       tags: iso
 
     - name: Download the KVM Guest Image file to /opt/autodeploy/resources/ISO
       get_url:
         url: "{{ kvm_get_url.url }}"
         dest: "{{ iso_path }}"
+      when: not (kvm_guest.stat.exists)
       tags: iso
 
-    - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms (Offline)
+    - name: Download the EPEL RPMs to /opt/autodeploy/resources/rpms when offline
       shell: repotrack $(cat {{ epel_rpm_file }}) -p {{ rpm_path }}
       when: offline
       tags: repo
 
-    - name: Download the Red Hat RPMs to /opt/autodeploy/resources/rpms (Offline)
+    - name: Download the Red Hat RPMs to /opt/autodeploy/resources/rpms when offline
       shell:
         repotrack $(cat {{ rhn_rpm_file }}) -p {{ rpm_path }}
         -r rhel-7-server-extras-rpms
@@ -118,19 +144,30 @@
       when: offline
       tags: repo
 
-    - name: Create the local repository in /opt/autodeploy/resources/rpms (Offline)
+    - name: Create the local repository in /opt/autodeploy/resources/rpms when offline
       command: createrepo "{{ rpm_path }}"
       when: offline
       tags: repo
 
-    - name: Mirror pip dependencies to /opt/autodeploy/resources/packages (Offline)
-      command: pip2tgz {{ packages_path }} -r {{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt
-      when: offline
+    - name: Check if docker-py files exist in /opt/autodeploy/resources/packages
+      stat:
+        path: "{{ packages_path }}/{{ docker_py_zip }}"
+      register: docker_py
       tags: docker
 
-    - name: Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages (Offline)
+    - name: Mirror pip dependencies to /opt/autodeploy/resources/packages when offline
+      command: pip2tgz {{ packages_path }} -r {{ projects_base_path }}/kragle/ansible/files/pip-requirements.txt
+      when: offline and not (docker_py.stat.exists)
+
+    - name: Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages
+      stat:
+        path: "{{ packages_path }}/simple"
+      register: simple
+      tags: docker
+
+    - name: Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages when offline
       command: dir2pi "{{ packages_path }}"
-      when: offline
+      when: offline and not (simple.stat.isdir is defined and simple.stat.isdir)
       tags: docker
 
     - name: Start and enable the docker service
@@ -140,47 +177,57 @@
         state: started
       tags: docker
 
+    - name: Check if Docker image files exist in /opt/autodeploy/resources/docker
+      stat:
+        path: "{{ docker_path }}/{{ item.tar_file }}"
+      with_items: docker_images
+      register: docker_img
+      tags: docker
+
     - name: Pull the project docker images from the docker registry
       docker:
         docker_api_version: "{{ docker_api_version }}"
-        name: "{{ item.name }}"
-        image: "{{ item.image }}"
+        name: "{{ item.item.name }}"
+        image: "{{ item.item.image }}"
         pull: always
         state: present
-      with_items:
-        - { name: hanlon-mongo, image: mongo }
-#        - { name: hanlon-cassandra, image: tobert/cassandra }
-        - { name: hanlon-server, image: cscdock/hanlon }
-        - { name: hanlon-atftpd, image: cscdock/atftpd }
+      with_items: docker_img.results
+      when: not (item.stat.exists)
       tags: docker
 
     - name: Save docker container images to /opt/autodeploy/resources/docker (Offline)
-      shell: docker save docker.io/"{{ item.image }}" > "{{ docker_path }}/{{ item.tar_file }}"
-      with_items:
-        - { image: cscdock/hanlon, tar_file: cscdock_hanlon.tar }
-        - { image: cscdock/atftpd, tar_file: cscdock_atftpd.tar }
-        - { image: mongo, tar_file: mongo.tar }
-      when: offline
+      shell: docker save docker.io/"{{ item.item.image }}" > "{{ docker_path }}/{{ item.item.tar_file }}"
+      with_items: docker_img.results
+      when: offline and not (item.stat.exists)
       tags: docker
+
+   - name: Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio
+      stat:
+        path: "{{ scaleio_path }}/{{ scaleio_source_zip }}"
+      register: scaleio_zip
+      tags: scaleio
 
     - name: Download ScaleIO files for ansible-scaleio to /opt/autodeploy/resources/scaleio
       get_url:
         url: "{{ scaleio_source_url }}"
         dest: "{{ scaleio_path }}"
+      when: not (scaleio_zip.stat.exists)
       tags: scaleio
 
-    - name: Copy the downloaded projects to the usb drive (Offline)
+    - name: Copy the downloaded projects to the usb drive when offline
       copy:
         src: "{{ projects_base_path }}/{{ item }}"
         dest: "{{ usb_projects_path }}"
+        force: no
       with_items: source_projects
       when: offline
       tags: copy
 
-    - name: Copy the downloaded resources to the usb drive (Offline)
+    - name: Copy the downloaded resources to the usb drive when offline
       copy:
         src: "{{ resources_base_path }}/{{ item }}"
         dest: "{{ usb_resources_path }}"
+        force: no
       with_items: resource_dirs
       when: offline
       tags: copy


### PR DESCRIPTION
Made Kragle idempotent except for the rpms where we are using repotrack. Need to find 'better' way to handle that?

```
[root@staging ansible]# ansible-playbook stage_resources.yml

PLAY [Prepare the staging resources] ******************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Install required support packages] *************************************
ok: [localhost] => (item=createrepo,dhcp,docker-1.7.1,firefox,genisoimage,httpd,ipmitool,iptables-services,ntp,python-netaddr,python-passlib,python-pip,python-xvfbwrapper,sshpass,unzip,vim,wget,xorg-x11-server-Xvfb,yum-utils)

TASK: [Install required pip-based support packages] ***************************
ok: [localhost]

TASK: [Create the staging directories in /opt/autodeploy] *********************
ok: [localhost] => (item=/opt/autodeploy/projects)
ok: [localhost] => (item=/opt/autodeploy/resources)

TASK: [Create the resource directories in the staging directories] ************
ok: [localhost] => (item=docker)
ok: [localhost] => (item=ISO)
ok: [localhost] => (item=packages)
ok: [localhost] => (item=rpms)
ok: [localhost] => (item=scaleio)

TASK: [Check if private project tar.gz exists in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Download the private project repo from Git to /opt/autodeploy/projects] ***
skipping: [localhost]

TASK: [Extract the private project source files] ******************************
skipping: [localhost]

TASK: [Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]

TASK: [Download the Hanlon microkernel image to /opt/autodeploy/resources/ISO] ***
skipping: [localhost]

TASK: [Check if RHEL DVD ISO file exists in /opt/autodeploy/resources/ISO] ****
ok: [localhost]

TASK: [Find the RHEL DVD ISO file url] ****************************************
skipping: [localhost]

TASK: [Download the RHEL DVD ISO file to /opt/autodeploy/resources/ISO] *******
skipping: [localhost]

TASK: [Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]

TASK: [Find the Red Hat KVM Guest Image file url] *****************************
skipping: [localhost]

TASK: [Download the KVM Guest Image file to /opt/autodeploy/resources/ISO] ****
skipping: [localhost]

TASK: [Download the EPEL RPMs to /opt/autodeploy/resources/rpms (Offline)] ****
changed: [localhost]

TASK: [Download the Red Hat RPMs to /opt/autodeploy/resources/rpms (Offline)] ***
changed: [localhost]

TASK: [Create the local repository in /opt/autodeploy/resources/rpms (Offline)] ***
changed: [localhost]

TASK: [Check if docker-py files exist in /opt/autodeploy/resources/packages] ***
ok: [localhost]

TASK: [Mirror pip dependencies to /opt/autodeploy/resources/packages (Offline)] ***
skipping: [localhost]

TASK: [Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages] ***
ok: [localhost]

TASK: [Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages (Offline)] ***
skipping: [localhost]

TASK: [Start and enable the docker service] ***********************************
ok: [localhost]

TASK: [Check if Docker image files exist in /opt/autodeploy/resources/docker] ***
ok: [localhost] => (item={'tar_file': 'mongo.tar', 'image': 'mongo', 'name': 'hanlon-mongo'})
ok: [localhost] => (item={'tar_file': 'cscdock_hanlon.tar', 'image': 'cscdock/hanlon', 'name': 'hanlon-server'})
ok: [localhost] => (item={'tar_file': 'cscdock_atftpd.tar', 'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'})

TASK: [Pull the project docker images from the docker registry] ***************
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//mongo.tar'}, 'module_args': ''}, 'item': {'tar_file': 'mongo.tar', 'image': 'mongo', 'name': 'hanlon-mongo'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423902.0524623, u'inode': 33709494, u'isgid': False, u'size': 267628032, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//mongo.tar', u'xusr': False, u'atime': 1447423932.4894605, u'md5': u'3442d2440c89f46e222ea71ec934fc43', u'isdir': False, u'ctime': 1447423902.0524623, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'53167eea564cc88d740f7b9dc86dcf26518a4448', u'islnk': False}, u'changed': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}, 'module_args': ''}, 'item': {'tar_file': 'cscdock_hanlon.tar', 'image': 'cscdock/hanlon', 'name': 'hanlon-server'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423917.1144614, u'inode': 33709495, u'isgid': False, u'size': 809053696, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar', u'xusr': False, u'atime': 1447423947.7644596, u'md5': u'efa752f602b911ed58214df1534a8016', u'isdir': False, u'ctime': 1447423917.1144614, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'e016eba05ee75af3c3bd1001f4eafc0bbbcd514c', u'islnk': False}, u'changed': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}, 'module_args': ''}, 'item': {'tar_file': 'cscdock_atftpd.tar', 'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423920.8194613, u'inode': 33709496, u'isgid': False, u'size': 222165504, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar', u'xusr': False, u'atime': 1447423993.765457, u'md5': u'effffd06c781ab3a5f197dbc75682e99', u'isdir': False, u'ctime': 1447423920.8194613, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'5c1cadb44bd12742f6c2d9a8bafab9fc3a55c8ea', u'islnk': False}, u'changed': False})

TASK: [Save docker container images to /opt/autodeploy/resources/docker (Offline)] ***
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//mongo.tar'}, 'module_args': ''}, 'item': {'tar_file': 'mongo.tar', 'image': 'mongo', 'name': 'hanlon-mongo'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423902.0524623, u'inode': 33709494, u'isgid': False, u'size': 267628032, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//mongo.tar', u'xusr': False, u'atime': 1447423932.4894605, u'md5': u'3442d2440c89f46e222ea71ec934fc43', u'isdir': False, u'ctime': 1447423902.0524623, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'53167eea564cc88d740f7b9dc86dcf26518a4448', u'islnk': False}, u'changed': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}, 'module_args': ''}, 'item': {'tar_file': 'cscdock_hanlon.tar', 'image': 'cscdock/hanlon', 'name': 'hanlon-server'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423917.1144614, u'inode': 33709495, u'isgid': False, u'size': 809053696, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar', u'xusr': False, u'atime': 1447423947.7644596, u'md5': u'efa752f602b911ed58214df1534a8016', u'isdir': False, u'ctime': 1447423917.1144614, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'e016eba05ee75af3c3bd1001f4eafc0bbbcd514c', u'islnk': False}, u'changed': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', 'module_complex_args': {'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}, 'module_args': ''}, 'item': {'tar_file': 'cscdock_atftpd.tar', 'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'}, u'stat': {u'uid': 0, u'exists': True, u'woth': False, u'mtime': 1447423920.8194613, u'inode': 33709496, u'isgid': False, u'size': 222165504, u'wgrp': False, u'isuid': False, u'isreg': True, u'pw_name': u'root', u'gid': 0, u'ischr': False, u'wusr': True, u'xoth': False, u'rusr': True, u'nlink': 1, u'issock': False, u'rgrp': True, u'gr_name': u'root', u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar', u'xusr': False, u'atime': 1447423993.765457, u'md5': u'effffd06c781ab3a5f197dbc75682e99', u'isdir': False, u'ctime': 1447423920.8194613, u'isblk': False, u'xgrp': False, u'dev': 64769, u'roth': True, u'isfifo': False, u'mode': u'0644', u'checksum': u'5c1cadb44bd12742f6c2d9a8bafab9fc3a55c8ea', u'islnk': False}, u'changed': False})

TASK: [Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio] *****
ok: [localhost]

TASK: [Download ScaleIO files for ansible-scaleio to /opt/autodeploy/resources/scaleio] ***
skipping: [localhost]

TASK: [Copy the downloaded projects to the usb drive (Offline)] ***************
ok: [localhost] => (item=ansible-scaleio)
ok: [localhost] => (item=kragle)
ok: [localhost] => (item=slimer)
ok: [localhost] => (item=wiley)

TASK: [Copy the downloaded resources to the usb drive (Offline)] **************
ok: [localhost] => (item=docker)
ok: [localhost] => (item=ISO)
ok: [localhost] => (item=packages)
ok: [localhost] => (item=rpms)
ok: [localhost] => (item=scaleio)

PLAY RECAP ********************************************************************
localhost                  : ok=21   changed=3    unreachable=0    failed=0
```