### PR TITLE
Bug fix for private repo extraction

### DIFF
--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -65,7 +65,7 @@
 
     - name: Extract the private project source files
       command: "tar -C {{ projects_base_path }}/wiley/ -xvzf {{ projects_base_path }}/wiley/{{ private_git_file}} --strip=1"
-      when: (extracted.stat.isdir is defined and simple.stat.isdir)
+      when: (extracted.stat.isdir is defined and extracted.stat.isdir)
       tags: git
 
     - name: Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO


### PR DESCRIPTION
```
[root@autodeploy72 ansible]# ansible-playbook stage_resources.yml --tags=git

PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Check if private project tar.gz exists in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Download the private project repo from Git to /opt/autodeploy/projects] ***
skipping: [localhost]

TASK: [Check if private project was extracted in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Extract the private project source files] ******************************
changed: [localhost]
```