### PR TITLE
Added build version specific value for Hanlon Docker container

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -96,7 +96,7 @@ iso_files:
 
 docker_images:
   - { name: hanlon-mongo, image: mongo, tar_file: mongo.tar }
-  - { name: hanlon-server, image: cscdock/hanlon, tar_file: cscdock_hanlon.tar }
+  - { name: hanlon-server, image: "cscdock/hanlon:2.5.0", tar_file: cscdock_hanlon.tar }
   - { name: hanlon-atftpd, image: cscdock/atftpd, tar_file: cscdock_atftpd.tar }
 
 resource_dirs:

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -18,7 +18,7 @@
       with_items:
         - { name: hanlon-mongo, image: mongo }
 #        - { name: hanlon-cassandra, image: tobert/cassandra }
-        - { name: hanlon-server, image: cscdock/hanlon }
+        - { name: hanlon-server, image: "cscdock/hanlon:2.5.0" }
         - { name: hanlon-atftpd, image: cscdock/atftpd }
 
     - name: Load Mongo, Hanlon and Atftpd Containers (Offline)
@@ -61,7 +61,7 @@
       docker:
         docker_api_version: "{{ docker_api_version }}"
         name: hanlon-server
-        image: cscdock/hanlon
+        image: "cscdock/hanlon:2.5.0"
         pull: missing
         state: started
         ports: 8026:8026


### PR DESCRIPTION
With the microkernel changes to Hanlon we need to specify
the specific version of the container we want to run until we
can update the Ansible modules and test the new microkernel.

Testing will follow.