### PR TITLE
Moving downloaded resources to RHEL 7.2

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -31,12 +31,12 @@ pxe_subnet_mask: x.x.x.x
 pxe_subnet_name: x.x.x.x
 
 hnl_mk_image: hnl_mk_debug-image.2.0.1.iso
-hnl_rhel_min_image: rhel-server-7.1-x86_64-dvd-hnl.iso
+hnl_rhel_min_image: rhel-server-7.2-x86_64-dvd-hnl.iso
 hnl_mk_source: https://github.com/csc/Hanlon-Microkernel/releases/download/v2.0.1/
 hnl_mk_local_path: /opt/hanlon/image/
 hnl_mk_path: /home/hanlon/image/{{ hnl_mk_image }}
-kvm_guest_image: rhel-guest-image-7.1-20150224.0.x86_64.qcow2
-rhel_iso_image: rhel-server-7.1-x86_64-dvd.iso
+kvm_guest_image: rhel-guest-image-7.2-20151102.0.x86_64.qcow2
+rhel_iso_image: rhel-server-7.2-x86_64-dvd.iso
 
 # Offline Staging vars
 git_user:
@@ -44,7 +44,7 @@ git_pass:
 private_git_repo: wiley
 private_git_file: wiley-0.1.3.tar.gz
 private_git_url: https://github.com/csc/wiley/archive/v0.1.3.tar.gz
-rhel_download_url: https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.1/x86_64/product-downloads
+rhel_download_url: https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.2/x86_64/product-downloads
 rhn_user:
 rhn_pass:
 pool:


### PR DESCRIPTION
```
[root@autodeploy72 ansible]# ansible-playbook stage_resources.yml --tags=iso

PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]
---

TASK: [Download the Hanlon microkernel image to /opt/autodeploy/resources/ISO] ***
skipping: [localhost]

TASK: [Check if RHEL DVD ISO file exists in /opt/autodeploy/resources/ISO] ****
ok: [localhost]

TASK: [Find the RHEL DVD ISO file url] ****************************************
ok: [localhost]

TASK: [Download the RHEL DVD ISO file to /opt/autodeploy/resources/ISO] *******
changed: [localhost]

TASK: [Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]

TASK: [Find the Red Hat KVM Guest Image file url] *****************************
ok: [localhost]

TASK: [Download the KVM Guest Image file to /opt/autodeploy/resources/ISO] ****
changed: [localhost]
```

```
TASK: [prep-projects | Create the Hanlon RHEL minimized ISO file if missing] ***
changed: [localhost]

TASK: [prep-projects | Check if RHEL minimized image is in the Hanlon image directory] ***
ok: [localhost]

TASK: [prep-projects | Copy RHEL minimized image to the Hanlon image directory] ***
changed: [localhost]
```