### PR TITLE
Configure the global Ansible config file

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -109,3 +109,16 @@
   ignore_errors: true
   with_items: tags.results
   when: not offline
+
+- name: Update default Ansible configuration
+  lineinfile:
+    dest: /etc/ansible/ansible.cfg
+    regexp: "(^#|^){{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - { regexp: 'inventory', line: 'inventory = ./hosts.ini' }
+    - { regexp: 'forks', line: 'forks = 20' }
+    - { regexp: 'host_key_checking', line: 'host_key_checking = False' }
+    - { regexp: 'log_path', line: 'log_path = ./ansible.log' }
+    - { regexp: 'ssh_args', line: 'ssh_args = -o ControlMaster=auto -o ControlPersist=60s' }
+    - { regexp: 'pipelining', line: 'pipelining = True' }


### PR DESCRIPTION
This PR updates the default Ansible config file to include the standard changes made for project related inventories.  Having an ansible.cfg file in each inventory location will no longer be required.  This change is in preparation for moving inventory management to a separate project.

```
TASK: [base | Update default Ansible configuration] ***************************
changed: [localhost] => (item={'regexp': 'inventory', 'line': 'inventory = ./hosts.ini'})
changed: [localhost] => (item={'regexp': 'forks', 'line': 'forks = 20'})
changed: [localhost] => (item={'regexp': 'host_key_checking', 'line': 'host_key_checking = False'})
changed: [localhost] => (item={'regexp': 'log_path', 'line': 'log_path = ./ansible.log'})
changed: [localhost] => (item={'regexp': 'ssh_args', 'line': 'ssh_args = -o ControlMaster=auto -o ControlPersist=60s'})
changed: [localhost] => (item={'regexp': 'pipelining', 'line': 'pipelining = True'})
```

Diff for ansible.cfg changes:
```
[root@autodeploy72 ansible]# diff ansible.cfg.orig ansible.cfg
14c14
< inventory      = /etc/ansible/hosts
---
> inventory = ./hosts.ini
18c18
< forks          = 5
---
> forks = 20
39c39
< #host_key_checking = False
---
> host_key_checking = False
56c56
< #log_path = /var/log/ansible.log
---
> log_path = ./ansible.log
184c184
< #ssh_args = -o ControlMaster=auto -o ControlPersist=60s
---
> ssh_args = -o ControlMaster=auto -o ControlPersist=60s
205c205
< #pipelining = False
---
> pipelining = True
```