### PR TITLE
Correcting git archive extract idempotence

### DIFF
--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -41,7 +41,7 @@
 
     - name: Check if private project tar.gz exists in /opt/autodeploy/projects
       stat:
-        path: "{{ projects_base_path }}/wiley/{{ private_git_file }}"
+        path: "{{ projects_base_path }}/{{ private_git_repo }}/{{ private_git_file }}"
       register: private_git
       tags: git
 
@@ -59,13 +59,13 @@
 
     - name: Check if private project was extracted in /opt/autodeploy/projects
       stat:
-        path: "{{ projects_base_path }}/{{ private_git_repo }}"
+        path: "{{ projects_base_path }}/{{ private_git_repo }}/roles"
       register: extracted
       tags: git
 
     - name: Extract the private project source files
-      command: "tar -C {{ projects_base_path }}/wiley/ -xvzf {{ projects_base_path }}/wiley/{{ private_git_file}} --strip=1"
-      when: (extracted.stat.isdir is defined and extracted.stat.isdir)
+      command: "tar -C {{ projects_base_path }}/{{ private_git_repo }}/ -xvzf {{ projects_base_path }}/{{ private_git_repo }}/{{ private_git_file}} --strip=1"
+      when: not (extracted.stat.isdir is defined and extracted.stat.isdir)
       tags: git
 
     - name: Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO


### PR DESCRIPTION
This PR corrects the checking of the private repo extraction so the archive is only extracted if the `roles` directory does not exist.  I chose `roles` because it seemed like a directory which would always exist for the project.  A folder inside the archive needed to be tested.  The Ansible `unarchive` module was investigated, but the extracted files were placed in a sub-directory named the same as the archive.  PRs to Ansible exist to enable passing addtional `tar` options but are not yet merged so using the module is not yet practical.

Testing:
```
[root@autodeploynode ansible]# ansible-playbook stage_resources.yml --tags=git

PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Check if private project tar.gz exists in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Download the private project repo from Git to /opt/autodeploy/projects] ***
ok: [localhost]

TASK: [Check if private project was extracted in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Extract the private project source files] ******************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=5    changed=1    unreachable=0    failed=0

[root@autodeploynode ansible]# ansible-playbook stage_resources.yml --tags=git

PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Check if private project tar.gz exists in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Download the private project repo from Git to /opt/autodeploy/projects] ***
skipping: [localhost]

TASK: [Check if private project was extracted in /opt/autodeploy/projects] ****
ok: [localhost]

TASK: [Extract the private project source files] ******************************
skipping: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```