### PR TITLE
Simplifying variables

### DIFF
--- a/ansible/inventory/group_vars/all.yml
+++ b/ansible/inventory/group_vars/all.yml
@@ -1,18 +1,15 @@
 ---
 # Offline autodeploy vars
-offline: true
+offline: false
 usb_hdd: /mnt/sdb
 use_scaleio: true
 use_wiley: true
 
 # Autodeploy common vars
-auto_deploy_node: x.x.x.x
 autodeploy_base_path: /opt/autodeploy
-dns1: x.x.x.x
 docker_api_version: 1.18
 docker_path: "{{ resources_base_path }}/docker/"
 docker_py_zip: docker-py-1.4.0.tar.gz
-hanlon_base_url: http://{{ auto_deploy_node }}:8026/hanlon/api/v1/
 iso_path: "{{ resources_base_path }}/ISO/"
 packages_path: "{{ resources_base_path }}/packages/"
 projects_base_path: "{{ autodeploy_base_path }}/projects"
@@ -23,12 +20,6 @@ rpm_path: "{{ resources_base_path }}/rpms/"
 scaleio_path: "{{ resources_base_path }}/scaleio/"
 
 # Autodeploy site_discovery vars:
-domain_name: localdomain
-pxe_dhcp_range_start: x.x.x.x
-pxe_dhcp_range_end: x.x.x.x
-pxe_gateway: x.x.x.x
-pxe_subnet_mask: x.x.x.x
-pxe_subnet_name: x.x.x.x
 
 hnl_mk_image: hnl_mk_debug-image.2.0.1.iso
 hnl_rhel_min_image: rhel-server-7.2-x86_64-dvd-hnl.iso

--- a/ansible/roles/dhcp-server/defaults/main.yml
+++ b/ansible/roles/dhcp-server/defaults/main.yml
@@ -1,13 +1,9 @@
 ---
 packer: false
 
-#options for EFI 32-bit - ipxe-x86.efi or snponly-x86.efi
-ipxe_efi_x86_rom: "ipxe-x86.efi"
+domain_name: "{{ ansible_domain }}"
+dns1: 8.8.8.8
 
-#options for EFI 64-bit - ipxe-x64.efi or snponly-x64.efi
-ipxe_efi_x64_rom: "ipxe-x64.efi"
-
-#options for legacy BIOS x86 mode - undionly.kpxe or ipxe.pxe
-ipxe_legacy_rom: "ipxe.pxe"
-
-hanlon_ipxe: "hanlon.ipxe"
+# Specify the last octet of the IP for the DHCP range
+dhcp_start: 20
+dhcp_end: 60

--- a/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
+++ b/ansible/roles/dhcp-server/templates/dhcpd.conf.j2
@@ -12,15 +12,15 @@ option hanlon_server code 224 = ip-address;
 option hanlon_port code 225 = unsigned integer 16;
 option hanlon_base_uri code 226 = text;
 
-subnet {{ pxe_subnet_name }} netmask {{ pxe_subnet_mask }} {
+subnet {{ ansible_default_ipv4.network }} netmask {{ ansible_default_ipv4.netmask }} {
     range                       {{ pxe_dhcp_range_start }} {{ pxe_dhcp_range_end }};
-    option routers              {{ pxe_gateway }};
-    option subnet-mask          {{ pxe_subnet_mask }};
+    option routers              {{ ansible_default_ipv4.gateway }};
+    option subnet-mask          {{ ansible_default_ipv4.netmask }};
     option domain-name          "{{ domain_name }}";
     option domain-name-servers  {{ dns1 }};
-    next-server                 {{ auto_deploy_node }};
-    option tftp-server-name     "{{ auto_deploy_node }}";
-    option hanlon_server        {{ auto_deploy_node }};
+    next-server                 {{ ansible_default_ipv4.address }};
+    option tftp-server-name     "{{ ansible_default_ipv4.address }}";
+    option hanlon_server        {{ ansible_default_ipv4.address }};
     option hanlon_port          8026;
     option hanlon_base_uri      "/hanlon/api/v1";
 

--- a/ansible/roles/dhcp-server/vars/main.yml
+++ b/ansible/roles/dhcp-server/vars/main.yml
@@ -1,0 +1,14 @@
+---
+pxe_dhcp_range_start: "{{ [ansible_default_ipv4.network, ansible_default_ipv4.netmask] | join('/') | ipaddr('net') | ipaddr(dhcp_start) | ipaddr('address') }}"
+pxe_dhcp_range_end: "{{ [ansible_default_ipv4.network, ansible_default_ipv4.netmask] | join('/') | ipaddr('net') | ipaddr(dhcp_end) | ipaddr('address') }}"
+
+#options for EFI 32-bit - ipxe-x86.efi or snponly-x86.efi
+ipxe_efi_x86_rom: "ipxe-x86.efi"
+
+#options for EFI 64-bit - ipxe-x64.efi or snponly-x64.efi
+ipxe_efi_x64_rom: "ipxe-x64.efi"
+
+#options for legacy BIOS x86 mode - undionly.kpxe or ipxe.pxe
+ipxe_legacy_rom: "ipxe.pxe"
+
+hanlon_ipxe: "hanlon.ipxe"

--- a/ansible/site_discovery.yml
+++ b/ansible/site_discovery.yml
@@ -5,6 +5,7 @@
   hosts: localhost
   vars:
     packer: false
+    hanlon_base_url: http://{{ ansible_default_ipv4.address }}:8026/hanlon/api/v1/
   roles:
     - dhcp-server
 


### PR DESCRIPTION
This PR cleans up the user required variables for a successful build.

The `auto_deploy_node` variable was replaced with `ansible_default_ipv4.address`
The `hanlon_base_url` was moved to the site_discovery.yml playbook where it is used.

The DHCP configuration variables have been moved to the dhcp-server role, with the user definable vars put in `defaults/main.yml` and the project vars put in `vars/main.yml`.  Sane defaults for testing have been configured.

Testing:
```
[root@rhel72 ansible]# ansible-playbook main.yml

PLAY [Stage DCAF automation resources on autodeploynode] **********************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [base | Install required support packages] ******************************
ok: [localhost] => (item=createrepo,dhcp,docker-1.7.1,firefox,genisoimage,httpd,ipmitool,iptables-services,ntp,python-netaddr,python-passlib,python-pip,python-xvfbwrapper,sshpass,unzip,vim,wget,xorg-x11-server-Xvfb,yum-utils)

TASK: [base | Install required pip-based support packages (Online)] ***********
ok: [localhost]

TASK: [base | Install required pip-based support packages (Offline)] **********
skipping: [localhost]

TASK: [base | Create the .ssh directory] **************************************
ok: [localhost]

TASK: [base | Create SSH Key Pair for root user] ******************************
ok: [localhost]

TASK: [base | Copy the .ssh/config file] **************************************
ok: [localhost]

TASK: [base | Retrieve deployment node public key] ****************************
changed: [localhost]

TASK: [base | Add deployment node SSH key to node authorized users] ***********
ok: [localhost]

TASK: [base | Disable firewalld] **********************************************
ok: [localhost]

TASK: [base | Create directories for hanlon] **********************************
changed: [localhost] => (item=/opt/hanlon)
ok: [localhost] => (item=/opt/hanlon/image)
ok: [localhost] => (item=/opt/deploy)

TASK: [base | Set the correct timezone] ***************************************
ok: [localhost]

TASK: [base | Configure NTP] **************************************************
ok: [localhost]

TASK: [base | Copy the iptables config file] **********************************
ok: [localhost]

TASK: [base | Start & enable iptables, ntpd & docker] *************************
changed: [localhost] => (item=iptables)
changed: [localhost] => (item=ntpd)
changed: [localhost] => (item=docker)

TASK: [base | Get latest tagged version of Git repos (Online)] ****************
ok: [localhost] => (item={'repo': 'git://github.com/csc/slimer', 'tag': 'https://api.github.com/repos/csc/slimer/tags', 'name': 'slimer'})
ok: [localhost] => (item={'repo': 'git://github.com/csc/kragle', 'tag': 'https://api.github.com/repos/csc/kragle/tags', 'name': 'kragle'})
ok: [localhost] => (item={'repo': 'git://github.com/csc/ansible-scaleio', 'tag': 'https://api.github.com/repos/csc/ansible-scaleio/tags', 'name': 'ansible-scaleio'})

TASK: [base | Clone source Git repos (Online)] ********************************
ok: [localhost] => (item={u'content_length': u'1586', u'status': 200, u'x_github_request_id': u'6B0FB8C1:14B61:C3FD6C1:5671C473', u'strict_transport_security': u'max-age=31536000; includeSubdomains; preload', u'content_location': u'https://api.github.com/repos/csc/slimer/tags', u'vary': u'Accept, Accept-Encoding', u'x_served_by': u'8a5c38021a5cd7cef7b8f49a296fee40', u'access_control_allow_origin': u'*', u'last_modified': u'Mon, 01 Jun 2015 14:37:54 GMT', u'content_type': u'application/json; charset=utf-8', u'x_ratelimit_limit': u'60', u'date': u'Wed, 16 Dec 2015 20:07:15 GMT', u'x_frame_options': u'deny', u'_content_encoding': u'gzip', u'x_ratelimit_reset': u'1450300035', u'x_github_media_type': u'github.v3; format=json', u'x_xss_protection': u'1; mode=block', u'transfer_encoding': u'chunked', u'changed': False, u'x_content_type_options': u'nosniff', u'access_control_allow_credentials': u'true', u'server': u'GitHub.com', u'access_control_expose_headers': u'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval', u'json': [{u'commit': {u'url': u'https://api.github.com/repos/csc/slimer/commits/0e34870984f95db48c99911561047520a0d5e541', u'sha': u'0e34870984f95db48c99911561047520a0d5e541'}, u'zipball_url': u'https://api.github.com/repos/csc/slimer/zipball/v1.0.1', u'tarball_url': u'https://api.github.com/repos/csc/slimer/tarball/v1.0.1', u'name': u'v1.0.1'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/slimer/commits/9affcdb09e8313bcc97969ebe47dcd117c8726ce', u'sha': u'9affcdb09e8313bcc97969ebe47dcd117c8726ce'}, u'zipball_url': u'https://api.github.com/repos/csc/slimer/zipball/v1.0.0', u'tarball_url': u'https://api.github.com/repos/csc/slimer/tarball/v1.0.0', u'name': u'v1.0.0'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/slimer/commits/83de530bc7e60121fb3e27f3a013700190d5287a', u'sha': u'83de530bc7e60121fb3e27f3a013700190d5287a'}, u'zipball_url': u'https://api.github.com/repos/csc/slimer/zipball/v0.1.3', u'tarball_url': u'https://api.github.com/repos/csc/slimer/tarball/v0.1.3', u'name': u'v0.1.3'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/slimer/commits/e49ad41c8de4185b6134988f59a32f15ab602cb2', u'sha': u'e49ad41c8de4185b6134988f59a32f15ab602cb2'}, u'zipball_url': u'https://api.github.com/repos/csc/slimer/zipball/v0.1.2', u'tarball_url': u'https://api.github.com/repos/csc/slimer/tarball/v0.1.2', u'name': u'v0.1.2'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/slimer/commits/800ddb77080610c267ec776857559379c54c0afe', u'sha': u'800ddb77080610c267ec776857559379c54c0afe'}, u'zipball_url': u'https://api.github.com/repos/csc/slimer/zipball/v0.1.1', u'tarball_url': u'https://api.github.com/repos/csc/slimer/tarball/v0.1.1', u'name': u'v0.1.1'}], u'etag': u'W/"845cdaa6e68b8dcf810c381f0d33be7e"', 'item': {'repo': 'git://github.com/csc/slimer', 'tag': 'https://api.github.com/repos/csc/slimer/tags', 'name': 'slimer'}, 'invocation': {'module_name': u'uri', 'module_complex_args': {'url': u'https://api.github.com/repos/csc/slimer/tags', 'method': 'GET'}, 'module_args': ''}, u'redirected': False, u'content_security_policy': u"default-src 'none'", u'cache_control': u'public, max-age=60, s-maxage=60', u'x_ratelimit_remaining': u'59'})
failed: [localhost] => (item={u'content_length': u'1586', u'status': 200, u'x_github_request_id': u'6B0FB8C1:14B5A:54CC919:5671C474', u'strict_transport_security': u'max-age=31536000; includeSubdomains; preload', u'content_location': u'https://api.github.com/repos/csc/kragle/tags', u'vary': u'Accept, Accept-Encoding', u'x_served_by': u'8dd185e423974a7e13abbbe6e060031e', u'access_control_allow_origin': u'*', u'last_modified': u'Thu, 27 Aug 2015 12:41:21 GMT', u'content_type': u'application/json; charset=utf-8', u'x_ratelimit_limit': u'60', u'date': u'Wed, 16 Dec 2015 20:07:16 GMT', u'x_frame_options': u'deny', u'_content_encoding': u'gzip', u'x_ratelimit_reset': u'1450300035', u'x_github_media_type': u'github.v3; format=json', u'x_xss_protection': u'1; mode=block', u'transfer_encoding': u'chunked', u'changed': False, u'x_content_type_options': u'nosniff', u'access_control_allow_credentials': u'true', u'server': u'GitHub.com', u'access_control_expose_headers': u'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval', u'json': [{u'commit': {u'url': u'https://api.github.com/repos/csc/kragle/commits/a89fdac2f4f1bd5b0b6eb85b9338491bb7d04bc1', u'sha': u'a89fdac2f4f1bd5b0b6eb85b9338491bb7d04bc1'}, u'zipball_url': u'https://api.github.com/repos/csc/kragle/zipball/v1.0.1', u'tarball_url': u'https://api.github.com/repos/csc/kragle/tarball/v1.0.1', u'name': u'v1.0.1'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/kragle/commits/3f3ae3f5ac1059271e90053def164225cd1445a4', u'sha': u'3f3ae3f5ac1059271e90053def164225cd1445a4'}, u'zipball_url': u'https://api.github.com/repos/csc/kragle/zipball/v1.0.0', u'tarball_url': u'https://api.github.com/repos/csc/kragle/tarball/v1.0.0', u'name': u'v1.0.0'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/kragle/commits/6c03ba5ae75ebf68e9aa742c390ae0d03c787313', u'sha': u'6c03ba5ae75ebf68e9aa742c390ae0d03c787313'}, u'zipball_url': u'https://api.github.com/repos/csc/kragle/zipball/v0.1.1', u'tarball_url': u'https://api.github.com/repos/csc/kragle/tarball/v0.1.1', u'name': u'v0.1.1'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/kragle/commits/32cf7e96f841c7f8a7cb5d0a9ac9e9761796263a', u'sha': u'32cf7e96f841c7f8a7cb5d0a9ac9e9761796263a'}, u'zipball_url': u'https://api.github.com/repos/csc/kragle/zipball/v0.1.0', u'tarball_url': u'https://api.github.com/repos/csc/kragle/tarball/v0.1.0', u'name': u'v0.1.0'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/kragle/commits/e36116c507a169c5a7efb2b87e51e1b47c096b57', u'sha': u'e36116c507a169c5a7efb2b87e51e1b47c096b57'}, u'zipball_url': u'https://api.github.com/repos/csc/kragle/zipball/v0.0.1', u'tarball_url': u'https://api.github.com/repos/csc/kragle/tarball/v0.0.1', u'name': u'v0.0.1'}], u'etag': u'W/"5e1469f0fe7489009f3d1e425de71057"', 'item': {'repo': 'git://github.com/csc/kragle', 'tag': 'https://api.github.com/repos/csc/kragle/tags', 'name': 'kragle'}, 'invocation': {'module_name': u'uri', 'module_complex_args': {'url': u'https://api.github.com/repos/csc/kragle/tags', 'method': 'GET'}, 'module_args': ''}, u'redirected': False, u'content_security_policy': u"default-src 'none'", u'cache_control': u'public, max-age=60, s-maxage=60', u'x_ratelimit_remaining': u'58'}) => {"failed": true, "item": {"_content_encoding": "gzip", "access_control_allow_credentials": "true", "access_control_allow_origin": "*", "access_control_expose_headers": "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval", "cache_control": "public, max-age=60, s-maxage=60", "changed": false, "content_length": "1586", "content_location": "https://api.github.com/repos/csc/kragle/tags", "content_security_policy": "default-src 'none'", "content_type": "application/json; charset=utf-8", "date": "Wed, 16 Dec 2015 20:07:16 GMT", "etag": "W/\"5e1469f0fe7489009f3d1e425de71057\"", "invocation": {"module_args": "", "module_complex_args": {"method": "GET", "url": "https://api.github.com/repos/csc/kragle/tags"}, "module_name": "uri"}, "item": {"name": "kragle", "repo": "git://github.com/csc/kragle", "tag": "https://api.github.com/repos/csc/kragle/tags"}, "json": [{"commit": {"sha": "a89fdac2f4f1bd5b0b6eb85b9338491bb7d04bc1", "url": "https://api.github.com/repos/csc/kragle/commits/a89fdac2f4f1bd5b0b6eb85b9338491bb7d04bc1"}, "name": "v1.0.1", "tarball_url": "https://api.github.com/repos/csc/kragle/tarball/v1.0.1", "zipball_url": "https://api.github.com/repos/csc/kragle/zipball/v1.0.1"}, {"commit": {"sha": "3f3ae3f5ac1059271e90053def164225cd1445a4", "url": "https://api.github.com/repos/csc/kragle/commits/3f3ae3f5ac1059271e90053def164225cd1445a4"}, "name": "v1.0.0", "tarball_url": "https://api.github.com/repos/csc/kragle/tarball/v1.0.0", "zipball_url": "https://api.github.com/repos/csc/kragle/zipball/v1.0.0"}, {"commit": {"sha": "6c03ba5ae75ebf68e9aa742c390ae0d03c787313", "url": "https://api.github.com/repos/csc/kragle/commits/6c03ba5ae75ebf68e9aa742c390ae0d03c787313"}, "name": "v0.1.1", "tarball_url": "https://api.github.com/repos/csc/kragle/tarball/v0.1.1", "zipball_url": "https://api.github.com/repos/csc/kragle/zipball/v0.1.1"}, {"commit": {"sha": "32cf7e96f841c7f8a7cb5d0a9ac9e9761796263a", "url": "https://api.github.com/repos/csc/kragle/commits/32cf7e96f841c7f8a7cb5d0a9ac9e9761796263a"}, "name": "v0.1.0", "tarball_url": "https://api.github.com/repos/csc/kragle/tarball/v0.1.0", "zipball_url": "https://api.github.com/repos/csc/kragle/zipball/v0.1.0"}, {"commit": {"sha": "e36116c507a169c5a7efb2b87e51e1b47c096b57", "url": "https://api.github.com/repos/csc/kragle/commits/e36116c507a169c5a7efb2b87e51e1b47c096b57"}, "name": "v0.0.1", "tarball_url": "https://api.github.com/repos/csc/kragle/tarball/v0.0.1", "zipball_url": "https://api.github.com/repos/csc/kragle/zipball/v0.0.1"}], "last_modified": "Thu, 27 Aug 2015 12:41:21 GMT", "redirected": false, "server": "GitHub.com", "status": 200, "strict_transport_security": "max-age=31536000; includeSubdomains; preload", "transfer_encoding": "chunked", "vary": "Accept, Accept-Encoding", "x_content_type_options": "nosniff", "x_frame_options": "deny", "x_github_media_type": "github.v3; format=json", "x_github_request_id": "6B0FB8C1:14B5A:54CC919:5671C474", "x_ratelimit_limit": "60", "x_ratelimit_remaining": "58", "x_ratelimit_reset": "1450300035", "x_served_by": "8dd185e423974a7e13abbbe6e060031e", "x_xss_protection": "1; mode=block"}}
msg: Local modifications exist in repository (force=no).
...ignoring
ok: [localhost] => (item={u'content_length': u'1033', u'status': 200, u'x_github_request_id': u'6B0FB8C1:14B63:C38FD60:5671C474', u'strict_transport_security': u'max-age=31536000; includeSubdomains; preload', u'content_location': u'https://api.github.com/repos/csc/ansible-scaleio/tags', u'vary': u'Accept, Accept-Encoding', u'x_served_by': u'173530fed4bbeb1e264b2ed22e8b5c20', u'access_control_allow_origin': u'*', u'last_modified': u'Fri, 07 Aug 2015 00:35:06 GMT', u'content_type': u'application/json; charset=utf-8', u'x_ratelimit_limit': u'60', u'date': u'Wed, 16 Dec 2015 20:07:16 GMT', u'x_frame_options': u'deny', u'_content_encoding': u'gzip', u'x_ratelimit_reset': u'1450300035', u'x_github_media_type': u'github.v3; format=json', u'x_xss_protection': u'1; mode=block', u'transfer_encoding': u'chunked', u'changed': False, u'x_content_type_options': u'nosniff', u'access_control_allow_credentials': u'true', u'server': u'GitHub.com', u'access_control_expose_headers': u'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval', u'json': [{u'commit': {u'url': u'https://api.github.com/repos/csc/ansible-scaleio/commits/d65f9b4ed01703056ced8497cee5b15d00c9330f', u'sha': u'd65f9b4ed01703056ced8497cee5b15d00c9330f'}, u'zipball_url': u'https://api.github.com/repos/csc/ansible-scaleio/zipball/v1.0.0', u'tarball_url': u'https://api.github.com/repos/csc/ansible-scaleio/tarball/v1.0.0', u'name': u'v1.0.0'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/ansible-scaleio/commits/bc36d54d557e59e1e4d201d19944aa0d9e2c5084', u'sha': u'bc36d54d557e59e1e4d201d19944aa0d9e2c5084'}, u'zipball_url': u'https://api.github.com/repos/csc/ansible-scaleio/zipball/v0.1.2', u'tarball_url': u'https://api.github.com/repos/csc/ansible-scaleio/tarball/v0.1.2', u'name': u'v0.1.2'}, {u'commit': {u'url': u'https://api.github.com/repos/csc/ansible-scaleio/commits/15aca7e868546f09bf219828662b93887041fbaf', u'sha': u'15aca7e868546f09bf219828662b93887041fbaf'}, u'zipball_url': u'https://api.github.com/repos/csc/ansible-scaleio/zipball/v0.1.1', u'tarball_url': u'https://api.github.com/repos/csc/ansible-scaleio/tarball/v0.1.1', u'name': u'v0.1.1'}], u'etag': u'W/"611484663ec6d13df528e6453674b54d"', 'item': {'repo': 'git://github.com/csc/ansible-scaleio', 'tag': 'https://api.github.com/repos/csc/ansible-scaleio/tags', 'name': 'ansible-scaleio'}, 'invocation': {'module_name': u'uri', 'module_complex_args': {'url': u'https://api.github.com/repos/csc/ansible-scaleio/tags', 'method': 'GET'}, 'module_args': ''}, u'redirected': False, u'content_security_policy': u"default-src 'none'", u'cache_control': u'public, max-age=60, s-maxage=60', u'x_ratelimit_remaining': u'57'})

TASK: [base | Update default Ansible configuration] ***************************
ok: [localhost] => (item={'regexp': 'inventory', 'line': 'inventory = ./hosts.ini'})
ok: [localhost] => (item={'regexp': 'forks', 'line': 'forks = 20'})
ok: [localhost] => (item={'regexp': 'host_key_checking', 'line': 'host_key_checking = False'})
ok: [localhost] => (item={'regexp': 'log_path', 'line': 'log_path = ./ansible.log'})
ok: [localhost] => (item={'regexp': 'ssh_args', 'line': 'ssh_args = -o ControlMaster=auto -o ControlPersist=60s'})
ok: [localhost] => (item={'regexp': 'pipelining', 'line': 'pipelining = True'})

TASK: [createrepo | Create offline HTTP repo directory] ***********************
skipping: [localhost]

TASK: [createrepo | Copy offline repo file to http directory] *****************
skipping: [localhost]

TASK: [createrepo | Create offline HTTP repository] ***************************
skipping: [localhost]

TASK: [createrepo | Create repo file to provide to hosts] *********************
skipping: [localhost]

TASK: [createrepo | Start the httpd service] **********************************
skipping: [localhost]

TASK: [prep-projects | Check if ScaleIO zip file exist in /opt/autodeploy/resources/scaleio] ***
ok: [localhost]

TASK: [prep-projects | Download ScaleIO files for ansible-scaleio project (Online)] ***
skipping: [localhost]

TASK: [prep-projects | Extract the ScaleIO source files] **********************
changed: [localhost]

TASK: [prep-projects | Find ScaleIO RPMs to be copied] ************************
changed: [localhost]

TASK: [prep-projects | Copy ScaleIO RPMs to the ansible-scaleio project] ******
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_Gateway_for_Linux_Download/EMC-ScaleIO-gateway-1.32-2451.4.noarch.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-callhome-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-lia-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-mdm-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sdc-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sds-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-tb-1.32-2451.4.el7.x86_64.rpm)

TASK: [prep-projects | Find ScaleIO Openstack driver file to extract] *********
changed: [localhost]

TASK: [prep-projects | Extract the ScaleIO OpenStack drivers] *****************
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_OpenStack_Driver_Download/EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip)

TASK: [prep-projects | Copy ScaleIO OpenStack-Compute Drivers to ansible-scaleio project] ***
ok: [localhost] => (item=scaleio.filters)
ok: [localhost] => (item=scaleio.py)
ok: [localhost] => (item=scaleio_config.py)
ok: [localhost] => (item=scaleio_install.py)
ok: [localhost] => (item=scaleiolibvirtdriver.py)

TASK: [prep-projects | Copy ScaleIO OpenStack-Controller Drivers to ansible-scaleio project] ***
ok: [localhost] => (item=scaleio.filters)
ok: [localhost] => (item=scaleio.py)
ok: [localhost] => (item=scaleio_config.py)
ok: [localhost] => (item=scaleio_install.py)
ok: [localhost] => (item=scaleiolibvirtdriver.py)

TASK: [prep-projects | Change the permissions on the minimize-rhel-iso.sh file] ***
ok: [localhost]

TASK: [prep-projects | Check if RHEL minimized image is in the resources directory] ***
ok: [localhost]

TASK: [prep-projects | Create the Hanlon RHEL minimized ISO file if missing] ***
skipping: [localhost]

TASK: [prep-projects | Check if RHEL minimized image is in the Hanlon image directory] ***
ok: [localhost]

TASK: [prep-projects | Copy RHEL minimized image to the Hanlon image directory] ***
skipping: [localhost]

PLAY [Start Hanlon Docker Environment] ****************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Clean up existing containers] ******************************************
changed: [localhost] => (item={'image': 'mongo', 'name': 'hanlon-mongo'})
changed: [localhost] => (item={'image': 'cscdock/hanlon:2.5.0', 'name': 'hanlon-server'})
changed: [localhost] => (item={'image': 'cscdock/atftpd', 'name': 'hanlon-atftpd'})

TASK: [Load Mongo, Hanlon and Atftpd Containers (Offline)] ********************
skipping: [localhost] => (item=docker_files)

TASK: [Start Mongo Container] *************************************************
changed: [localhost]

TASK: [Remove hanlon client config file] **************************************
changed: [localhost]

TASK: [Start Hanlon Server Container] *****************************************
changed: [localhost]

TASK: [Wait for Hanlon Server to start] ***************************************
ok: [localhost]

TASK: [Start TFTP Server Container] *******************************************
changed: [localhost]

PLAY [Configure deployment node for site discovery] ***************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [dhcp-server | install dhcp server package] *****************************
ok: [localhost]

TASK: [dhcp-server | Configure dhcpd.conf] ************************************
ok: [localhost]

TASK: [dhcp-server | Configure ipxe.conf] *************************************
ok: [localhost]

TASK: [dhcp-server | Copy ipxe-option-space.conf] *****************************
ok: [localhost]

TASK: [dhcp-server | enable dhcpd service] ************************************
ok: [localhost]

TASK: [Check for local copy of Hanlon Microkernel] ****************************
ok: [localhost]

TASK: [Download Hanlon Microkernel (Online)] **********************************
skipping: [localhost]

TASK: [Copy Hanlon Microkernel to /opt/hanlon/image (Offline)] ****************
skipping: [localhost]

TASK: [Add a Microkernel Image to Hanlon] *************************************
ok: [localhost]

TASK: [Add a Discover Only Model to Hanlon] ***********************************
ok: [localhost]

TASK: [Add a Discover Only Policy to Hanlon] **********************************
ok: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=46   changed=12   unreachable=0    failed=0
```
