### PR TITLE
Syntax updates for Ansible 2.0

### DIFF
--- a/ansible/roles/verify-files/tasks/main.yml
+++ b/ansible/roles/verify-files/tasks/main.yml
@@ -4,40 +4,40 @@
 - name: Check if source project files exist on autodeploynode
   stat:
     path: "{{ projects_base_path }}/{{ item }}"
-  with_items: project_files
+  with_items: "{{ project_files }}"
   register: git_present
 
 - name: Copy source project files to autodeploynode when offline
   copy:
     src: "{{ item.invocation.module_complex_args.path }}"
     dest: "{{ projects_base_path }}"
-  with_items: git_present.results
+  with_items: "{{ git_present.results }}"
   when: not {{ item.stat.exists }}
 
 - name: Check if source ISO files exist on autodeploynode
   stat:
     path: "{{ iso_path }}/{{ item }}"
-  with_items: iso_files
+  with_items: "{{ iso_files }}"
   register: iso_present
 
 - name: Copy source ISO files to autodeploynode when offline
   copy:
     src: "{{ item.invocation.module_complex_args.path }}"
     dest: "{{ iso_path }}"
-  with_items: iso_present.results
+  with_items: "{{ iso_present.results }}"
   when: not {{ item.stat.exists }}
 
 - name: Check if source docker files exist on autodeploynode
   stat:
-    path: "{{ docker_path }}/{{ item }}"
-  with_items: docker_files
+    path: "{{ docker_path }}/{{ item.tar_file }}"
+  with_items: "{{ docker_images }}"
   register: docker_present
 
 - name: Copy source docker files to autodeploynode when offline
   copy:
     src: "{{ item.invocation.module_complex_args.path }}"
     dest: "{{ docker_path }}"
-  with_items: docker_present.results
+  with_items: "{{ docker_present.results }}"
   when: not {{ item.stat.exists }}
 
 - name: Copy source python package files to autodeploynode when offline
@@ -52,7 +52,7 @@
   copy:
     src: "{{ usb_rpms_path }}/{{ item }}.rpm"
     dest: "{{ rpm_path }}"
-  with_items: contents.splitlines()
+  with_items: "{{ contents.splitlines() }}"
 
 - name: Check if source scaleio files exist on autodeploynode
   stat:
@@ -65,6 +65,6 @@
   copy:
     src: "{{ item.invocation.module_complex_args.path }}"
     dest: "{{ scaleio_path }}"
-  with_items: scaleio_present.results
+  with_items: "{{ scaleio_present.results }}"
   when: not {{ item.stat.exists }}
 

--- a/ansible/site_docker.yml
+++ b/ansible/site_docker.yml
@@ -22,8 +22,8 @@
         - { name: hanlon-atftpd, image: cscdock/atftpd }
 
     - name: Load Mongo, Hanlon and Atftpd Containers (Offline)
-      command: docker load --input "{{ docker_path }}/{{ item }}"
-      with_items: docker_files
+      command: docker load --input "{{ docker_path }}/{{ item.tar_file }}"
+      with_items: "{{ docker_images }}"
       when: offline
 
     - name: Start Mongo Container


### PR DESCRIPTION
Bare variables are no longer allowed for `with_items` task attributes.  While correcting this syntax, a bug was discovered which was introduced In November when some variable changes were made and the `docker_files` dictionary was replaced by `docker_images`.  This bug has also been corrected.  The `verify_files` role is not currently in use, however the code in this role has been updated.

Testing (online):
```
TASK [Load Mongo, Hanlon and Atftpd Containers (Offline)] **********************
skipping: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})
```