### PR TITLE
kragle - create repo mods

### DIFF
--- a/ansible/roles/createrepo/tasks/main.yml
+++ b/ansible/roles/createrepo/tasks/main.yml
@@ -7,9 +7,9 @@
     dest: "{{ rpm_path }}"
 
 - name: Create offline repo config for httpd
-    template:
-      src: offline_repo.conf
-      dest: "/etc/httpd/conf.d/"
+  template:
+    src: offline_repo.conf
+    dest: "/etc/httpd/conf.d/"
 
 - name: Start the httpd service
   service:

--- a/ansible/roles/createrepo/tasks/main.yml
+++ b/ansible/roles/createrepo/tasks/main.yml
@@ -1,23 +1,15 @@
 ---
 # The createrepo role will create an offline http repo for use when internet connectivity is not available.
 
-- name: Create offline HTTP repo directory
-  file:
-    path: "/var/www/html/repo"
-    state: directory
-
-- name: Copy offline repo file to http directory
-  copy:
-    src: "{{ rpm_path }}/"
-    dest: "/var/www/html/repo"
-
-- name: Create offline HTTP repository
-  command: createrepo "/var/www/html/repo"
-
-- name: Create repo file to provide to hosts
+- name: Create offline repo file to provide to hosts
   template:
     src: offline.repo.j2
-    dest: "/var/www/html/repo/offline.repo"
+    dest: "{{ rpm_path }}"
+
+- name: Create offline repo config for httpd
+    template:
+      src: offline_repo.conf
+      dest: "/etc/httpd/conf.d/"
 
 - name: Start the httpd service
   service:

--- a/ansible/roles/createrepo/templates/offline_repo.conf
+++ b/ansible/roles/createrepo/templates/offline_repo.conf
@@ -1,0 +1,6 @@
+<Directory "{{ rpm_path }}">
+    Options Indexes FollowSymLinks
+    Require all granted
+</Directory>
+
+Alias /repo {{ rpm_path }}


### PR DESCRIPTION
Changed the createrepo role so that the offline repo created by stage_resources can be used by other projects.

```
PLAY [Test for Kragle] ********************************************************

GATHERING FACTS ***************************************************************
ok: [localhost]

TASK: [Create offline repo file to provide to hosts] **************************
changed: [localhost]

TASK: [Create repo file to provide to hosts] **********************************
ok: [localhost]

TASK: [Start the httpd service] ***********************************************
changed: [localhost]

PLAY RECAP ********************************************************************
localhost                  : ok=4    changed=2    unreachable=0    failed=0
```