### PR TITLE
Fix bugs for scaleio prep-projects

### DIFF
--- a/ansible/roles/base/tasks/main.yml
+++ b/ansible/roles/base/tasks/main.yml
@@ -99,6 +99,7 @@
     accept_hostkey: yes
     key_file: "{{ github_key_file }}"
   with_items: "{{ git_repos }}"
+  ignore_errors: true
   when: not offline
 
 - name: Checkout the latest tagged version

--- a/ansible/roles/prep-projects/tasks/scaleio.yml
+++ b/ansible/roles/prep-projects/tasks/scaleio.yml
@@ -14,11 +14,11 @@
   register: download_file
   when: not (scaleio_zip.stat.exists or offline)
 
+# TODO Test if the source file has been extracted
 - name: Extract the ScaleIO source files
   unarchive:
     src: "{{ scaleio_path }}/{{ scaleio_source_zip }}"
     dest: "{{ scaleio_path }}"
-  when: scaleio_zip.stat.exists
 
 - name: Find ScaleIO RPMs to be copied
   shell: 'find {{ scaleio_path }} -type f -name "*.rpm" | egrep "RHEL7|Gateway" | egrep -v "MACOSX"'

--- a/ansible/roles/prep-projects/vars/main.yml
+++ b/ansible/roles/prep-projects/vars/main.yml
@@ -4,8 +4,6 @@ ansible_scaleio_path: "{{ projects_base_path }}/ansible-scaleio/"
 scaleio_rpm_path: "{{ ansible_scaleio_path }}/files/"
 scaleio_compute_path: "{{ ansible_scaleio_path }}/roles/openstack-compute/files/"
 scaleio_controllers_path: "{{ ansible_scaleio_path }}/roles/openstack-controllers/files/"
-scaleio_source_zip: ScaleIO_1.32.2_Linux_SW_Download.zip
-scaleio_source_url: "http://downloads.emc.com/emc-com/usa/{{ scaleio_source_zip }}"
 scaleio_os_driver_zip: EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip
 
 scaleio_gw_files:

--- a/ansible/stage_resources.yml
+++ b/ansible/stage_resources.yml
@@ -46,6 +46,7 @@
         accept_hostkey: yes
         key_file: "{{ github_key_file }}"
       with_items: "{{ git_repos }}"
+      ignore_errors: true
 
     - name: Checkout the latest tagged version
       shell: "git checkout $(git describe --abbrev=0 --tags)"


### PR DESCRIPTION
This PR fixes some bugs in the scaleio section of the prep-projects role.

Variables were specified in two locations and one of them was incorrect.  With changes in Ansible versions the variable precedence changed and started picking up the incorrect variable.  Additionally, a task conditional was not running correctly if the file didn't exist and therefore caused another task failure because the downloaded zip file was not being extracted.

Error:
```
TASK [prep-projects : Download ScaleIO files for ansible-scaleio project (Online)] ***
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/opt/autodeploy/resources/scaleio/", "failed": true, "gid": 0, "group": "root", "mode": "0755", "msg": "Request failed", "owner": "root", "response": "HTTP Error 404: Not Found", "secontext": "unconfined_u:object_r:usr_t:s0", "size": 6, "state": "directory", "status_code": 404, "uid": 0, "url": "http://downloads.emc.com/emc-com/usa/ScaleIO_1.32.2_Linux_SW_Download.zip"}
```

Testing (scaleio section of prep-projects):
```
TASK [prep-projects : include] *************************************************
included: /opt/autodeploy/projects/kragle/ansible/roles/prep-projects/tasks/scaleio.yml for localhost

TASK [prep-projects : Check if ScaleIO zip file exist in /opt/autodeploy/resources/scaleio] ***
ok: [localhost]

TASK [prep-projects : Download ScaleIO files for ansible-scaleio project (Online)] ***
skipping: [localhost]

TASK [prep-projects : Extract the ScaleIO source files] ************************
changed: [localhost]

TASK [prep-projects : Find ScaleIO RPMs to be copied] **************************
changed: [localhost]

TASK [prep-projects : Copy ScaleIO RPMs to the ansible-scaleio project] ********
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_Gateway_for_Linux_Download/EMC-ScaleIO-gateway-1.32-2451.4.noarch.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-callhome-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-lia-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-mdm-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sdc-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sds-1.32-2451.4.el7.x86_64.rpm)
ok: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-tb-1.32-2451.4.el7.x86_64.rpm)

TASK [prep-projects : Find ScaleIO Openstack driver file to extract] ***********
changed: [localhost]

TASK [prep-projects : Extract the ScaleIO OpenStack drivers] *******************
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_OpenStack_Driver_Download/EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip)

TASK [prep-projects : Copy ScaleIO OpenStack-Compute Drivers to ansible-scaleio project] ***
ok: [localhost] => (item=scaleio.filters)
ok: [localhost] => (item=scaleio.py)
ok: [localhost] => (item=scaleio_config.py)
ok: [localhost] => (item=scaleio_install.py)
ok: [localhost] => (item=scaleiolibvirtdriver.py)

TASK [prep-projects : Copy ScaleIO OpenStack-Controller Drivers to ansible-scaleio project] ***
ok: [localhost] => (item=scaleio.filters)
ok: [localhost] => (item=scaleio.py)
ok: [localhost] => (item=scaleio_config.py)
ok: [localhost] => (item=scaleio_install.py)
ok: [localhost] => (item=scaleiolibvirtdriver.py)
```

Additionally, `ignore_errors` have been added to git cloning tasks to allow the playbook to continue if there are local modifications in existing local clones.