### PR TITLE
Updating Ansible RPM build to use tagged release

### DIFF
--- a/ansible/build.sh
+++ b/ansible/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# DCAF Lab AutoDeploy Node Installation (BUILD RPM)
-# =====================================
+# DCAF AutoDeploy Node Installation
+# =================================
 # Prior to running this script, the following exports must be configured
 # export RHN_USER="username"
 # export RHN_PASS="password"    # escape dollar signs (\$)
@@ -16,8 +16,9 @@
 # chmod 0600 ~/github.pem
 
 # Once these prerequisites are in place, the script can be executed by:
-# curl https://raw.githubusercontent.com/csc/kragle/master/ansible/init.sh | bash
+# curl https://raw.githubusercontent.com/csc/kragle/master/ansible/build.sh | bash
 
+# TODO Add error handling to exit if a command fails along the way
 
 subscription-manager register --username=$RHN_USER  --password=$RHN_PASS
 subscription-manager attach --pool=$RHN_POOL
@@ -29,7 +30,7 @@ yum -y install git wget rpm-build make asciidoc python2-devel python-setuptools
 
 git clone git://github.com/ansible/ansible.git --recursive
 cd ansible/
-git checkout stable-2.0
+git checkout v2.0.1.0-0.1.rc1
 git submodule update --init --recursive
 make rpm
 yum -y --nogpgcheck localinstall ./rpm-build/ansible-*.noarch.rpm


### PR DESCRIPTION
Ansible branch stable-2.0 is not stable.  They are committing small changes which makes working code fail.   A tagged release is much more stable in the sense it is not a moving target and gives us the stability we need to be able to develop and test our code.  This PR updates the build script to use a tagged release (v2.0.1.0-0.1.rc1).

Note: The script was renamed from init.sh to build.sh to more accurately reflect it's function.

Testing (after Ansible RPM build):
```
Installed:
  ansible.noarch 0:2.0.1.0-0.git201601282137.870a4b8.HEAD.el7

Dependency Installed:
  PyYAML.x86_64 0:3.10-11.el7               libtomcrypt.x86_64 0:1.17-23.el7           libtommath.x86_64 0:0.42.0-4.el7
  libyaml.x86_64 0:0.1.4-11.el7_0           python-babel.noarch 0:1.3-6.el7ost         python-ecdsa.noarch 0:0.11-3.el7ost
  python-httplib2.noarch 0:0.7.7-3.el7ost   python-jinja2.noarch 0:2.7.2-2.el7         python-keyczar.noarch 0:0.71c-2.el7
  python-markupsafe.x86_64 0:0.11-10.el7    python-paramiko.noarch 0:1.15.1-1.el7ost   python-pyasn1.noarch 0:0.1.6-2.el7
  python-six.noarch 0:1.9.0-2.el7           python2-crypto.x86_64 0:2.6.1-9.el7        pytz.noarch 0:2012d-5.el7
  sshpass.x86_64 0:1.05-5.el7

Complete!
--2016-02-11 10:30:47--  https://raw.githubusercontent.com/csc/kragle/master/ansible/initial_stage.yml
Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 23.235.39.133
Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|23.235.39.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1267 (1.2K) [text/plain]
Saving to: ‘initial_stage.yml’

100%[==================================================================================>] 1,267       --.-K/s   in 0s

2016-02-11 10:30:48 (298 MB/s) - ‘initial_stage.yml’ saved [1267/1267]

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [Download the Kragle source repo] *****************************************

TASK [Create the staging directories] ******************************************
changed: [localhost] => (item=/opt/autodeploy/projects)
changed: [localhost] => (item=/opt/autodeploy/resources)

TASK [Clone the project repos from Git] ****************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/kragle.git', u'name': u'kragle'})

TASK [Checkout the latest tagged version] **************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/kragle.git', u'name': u'kragle'})

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=3    unreachable=0    failed=0


PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Install required support packages] ***************************************
changed: [localhost] => (item=[u'createrepo', u'dhcp', u'docker-1.7.1', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686'])

TASK [Install required pip-based support packages] *****************************
changed: [localhost]

TASK [Create the staging directories in /opt/autodeploy] ***********************
ok: [localhost] => (item=/opt/autodeploy/projects)
ok: [localhost] => (item=/opt/autodeploy/resources)

TASK [Create the resource directories in the staging directories] **************
changed: [localhost] => (item=docker)
changed: [localhost] => (item=ISO)
changed: [localhost] => (item=packages)
changed: [localhost] => (item=rpms)
changed: [localhost] => (item=scaleio)

TASK [Clone the project repos from Git] ****************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/wiley.git', u'name': u'wiley'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [Checkout the latest tagged version] **************************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/wiley.git', u'name': u'wiley'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [Check if Hanlon Microkernel file exists in /opt/autodeploy/resources/ISO]
ok: [localhost]

TASK [Download the Hanlon microkernel image to /opt/autodeploy/resources/ISO] **
changed: [localhost]

TASK [Check if RHEL DVD ISO file exists in /opt/autodeploy/resources/ISO] ******
ok: [localhost]

TASK [Find the RHEL DVD ISO file url] ******************************************
ok: [localhost]

TASK [Download the RHEL DVD ISO file to /opt/autodeploy/resources/ISO] *********
changed: [localhost]

TASK [Check if Red Hat KVM Guest image file exists in /opt/autodeploy/resources/ISO] ***
ok: [localhost]

TASK [Find the Red Hat KVM Guest Image file url] *******************************
ok: [localhost]

TASK [Download the KVM Guest Image file to /opt/autodeploy/resources/ISO] ******
changed: [localhost]

TASK [Download the EPEL RPMs to /opt/autodeploy/resources/rpms when offline] ***
skipping: [localhost]

TASK [Download the Red Hat RPMs to /opt/autodeploy/resources/rpms when offline]
skipping: [localhost]

TASK [Create the local repository in /opt/autodeploy/resources/rpms when offline] ***
skipping: [localhost]

TASK [Check if docker-py files exist in /opt/autodeploy/resources/packages] ****
ok: [localhost]

TASK [Mirror pip dependencies to /opt/autodeploy/resources/packages when offline] ***
skipping: [localhost]

TASK [Check if PyPi-compatible "simple" package exists in /opt/autodeploy/resources/packages] ***
ok: [localhost]

TASK [Create the PyPi-compatible "simple" package in /opt/autodeploy/resources/packages when offline] ***
skipping: [localhost]

TASK [Start and enable the docker service] *************************************
changed: [localhost]

TASK [Check if Docker image files exist in /opt/autodeploy/resources/docker] ***
ok: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
ok: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
ok: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Pull the project docker images from the docker registry] *****************
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
changed: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

TASK [Save docker container images to /opt/autodeploy/resources/docker (Offline)] ***
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//mongo.tar'}}, 'item': {u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_hanlon.tar'}}, 'item': {u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})
skipping: [localhost] => (item={'invocation': {'module_name': u'stat', u'module_args': {u'checksum_algorithm': u'sha1', u'get_md5': True, u'follow': False, u'get_checksum': True, u'path': u'/opt/autodeploy/resources/docker//cscdock_atftpd.tar'}}, 'item': {u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'}, u'stat': {u'exists': False}, u'changed': False, '_ansible_no_log': False})

TASK [Check if ScaleIO files exist in /opt/autodeploy/resources/scaleio] *******
ok: [localhost]

TASK [Download ScaleIO files for ansible-scaleio to /opt/autodeploy/resources/scaleio] ***
changed: [localhost]

TASK [Copy the downloaded projects to the usb drive when offline] **************
skipping: [localhost] => (item=ansible-scaleio)
skipping: [localhost] => (item=kragle)
skipping: [localhost] => (item=slimer)
skipping: [localhost] => (item=wiley)

TASK [Copy the downloaded resources to the usb drive when offline] *************
skipping: [localhost] => (item=docker)
skipping: [localhost] => (item=ISO)
skipping: [localhost] => (item=packages)
skipping: [localhost] => (item=rpms)
skipping: [localhost] => (item=scaleio)

PLAY RECAP *********************************************************************
localhost                  : ok=22   changed=11   unreachable=0    failed=0


PLAY [Stage DCAF automation resources on autodeploynode] ***********************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [base : Install required support packages] ********************************
ok: [localhost] => (item=[u'createrepo', u'dhcp', u'docker-1.7.1', u'firefox', u'genisoimage', u'httpd', u'ipmitool', u'iptables-services', u'ntp', u'python-netaddr', u'python-passlib', u'python-pip', u'python-xvfbwrapper', u'sshpass', u'unzip', u'vim', u'wget', u'xorg-x11-server-Xvfb', u'yum-utils', u'openssl-devel', u'glibc.i686'])

TASK [base : Install required pip-based support packages (Online)] *************
ok: [localhost]

TASK [base : Install required pip-based support packages (Offline)] ************
skipping: [localhost]

TASK [base : Create the .ssh directory] ****************************************
ok: [localhost]

TASK [base : Create SSH Key Pair for root user] ********************************
changed: [localhost]

TASK [base : Copy the .ssh/config file] ****************************************
changed: [localhost]

TASK [base : Retrieve deployment node public key] ******************************
changed: [localhost]

TASK [base : Add deployment node SSH key to node authorized users] *************
changed: [localhost]

TASK [base : Disable firewalld] ************************************************
changed: [localhost]

TASK [base : Create directories for hanlon] ************************************
changed: [localhost] => (item=/opt/hanlon)
changed: [localhost] => (item=/opt/hanlon/image)
changed: [localhost] => (item=/opt/deploy)

TASK [base : Set the correct timezone] *****************************************
changed: [localhost]

TASK [base : Configure NTP] ****************************************************
changed: [localhost]

TASK [base : Copy the iptables config file] ************************************
changed: [localhost]

TASK [base : Start & enable iptables, ntpd & docker] ***************************
changed: [localhost] => (item=iptables)
changed: [localhost] => (item=ntpd)
changed: [localhost] => (item=docker)

TASK [base : Clone the project repos from Git] *********************************
ok: [localhost] => (item={u'repo': u'git@github.com:csc/wiley.git', u'name': u'wiley'})
ok: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
ok: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [base : Checkout the latest tagged version] *******************************
changed: [localhost] => (item={u'repo': u'git@github.com:csc/wiley.git', u'name': u'wiley'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/slimer.git', u'name': u'slimer'})
changed: [localhost] => (item={u'repo': u'git@github.com:csc/ansible-scaleio.git', u'name': u'ansible-scaleio'})

TASK [base : Update default Ansible configuration] *****************************
changed: [localhost] => (item={u'regexp': u'inventory', u'line': u'inventory = ./hosts.ini'})
changed: [localhost] => (item={u'regexp': u'forks', u'line': u'forks = 20'})
changed: [localhost] => (item={u'regexp': u'host_key_checking', u'line': u'host_key_checking = False'})
changed: [localhost] => (item={u'regexp': u'log_path', u'line': u'log_path = ./ansible.log'})
changed: [localhost] => (item={u'regexp': u'ssh_args', u'line': u'ssh_args = -o ControlMaster=auto -o ControlPersist=60s'})
changed: [localhost] => (item={u'regexp': u'pipelining', u'line': u'pipelining = True'})

TASK [createrepo : Create offline repo file to provide to hosts] ***************
skipping: [localhost]

TASK [createrepo : Create offline repo config for httpd] ***********************
skipping: [localhost]

TASK [createrepo : Start the httpd service] ************************************
skipping: [localhost]

TASK [prep-projects : include] *************************************************
included: /opt/autodeploy/projects/kragle/ansible/roles/prep-projects/tasks/scaleio.yml for localhost

TASK [prep-projects : Check if ScaleIO zip file exist in /opt/autodeploy/resources/scaleio] ***
ok: [localhost]

TASK [prep-projects : Download ScaleIO files for ansible-scaleio project (Online)] ***
skipping: [localhost]

TASK [prep-projects : Extract the ScaleIO source files] ************************
changed: [localhost]

TASK [prep-projects : Find ScaleIO RPMs to be copied] **************************
changed: [localhost]

TASK [prep-projects : Copy ScaleIO RPMs to the ansible-scaleio project] ********
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_Gateway_for_Linux_Download/EMC-ScaleIO-gateway-1.32-2451.4.noarch.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-callhome-1.32-2451.4.el7.x86_64.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-lia-1.32-2451.4.el7.x86_64.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-mdm-1.32-2451.4.el7.x86_64.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sdc-1.32-2451.4.el7.x86_64.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-sds-1.32-2451.4.el7.x86_64.rpm)
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_RHEL7_Download/EMC-ScaleIO-tb-1.32-2451.4.el7.x86_64.rpm)

TASK [prep-projects : Find ScaleIO Openstack driver file to extract] ***********
changed: [localhost]

TASK [prep-projects : Extract the ScaleIO OpenStack drivers] *******************
changed: [localhost] => (item=/opt/autodeploy/resources/scaleio/ScaleIO_1.32.2_OpenStack_Driver_Download/EMC-ScaleIO-openstack-driver-1.32-2451.4-juno.zip)

TASK [prep-projects : Copy ScaleIO OpenStack-Compute Drivers to ansible-scaleio project] ***
changed: [localhost] => (item=scaleio.filters)
changed: [localhost] => (item=scaleio.py)
changed: [localhost] => (item=scaleio_config.py)
changed: [localhost] => (item=scaleio_install.py)
changed: [localhost] => (item=scaleiolibvirtdriver.py)

TASK [prep-projects : Copy ScaleIO OpenStack-Controller Drivers to ansible-scaleio project] ***
changed: [localhost] => (item=scaleio.filters)
changed: [localhost] => (item=scaleio.py)
changed: [localhost] => (item=scaleio_config.py)
changed: [localhost] => (item=scaleio_install.py)
changed: [localhost] => (item=scaleiolibvirtdriver.py)

TASK [prep-projects : include] *************************************************
included: /opt/autodeploy/projects/kragle/ansible/roles/prep-projects/tasks/wiley.yml for localhost

TASK [prep-projects : Change the permissions on the minimize-rhel-iso.sh file] *
changed: [localhost]

TASK [prep-projects : Check if RHEL minimized image is in the resources directory] ***
ok: [localhost]

TASK [prep-projects : Create the Hanlon RHEL minimized ISO file if missing] ****
changed: [localhost]

TASK [prep-projects : Check if RHEL minimized image is in the Hanlon image directory] ***
ok: [localhost]

TASK [prep-projects : Copy RHEL minimized image to the Hanlon image directory] *
changed: [localhost]

PLAY [Start Hanlon Docker Environment] *****************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Clean up existing containers] ********************************************
changed: [localhost] => (item={u'image': u'mongo', u'name': u'hanlon-mongo'})
changed: [localhost] => (item={u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
changed: [localhost] => (item={u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Load Mongo, Hanlon and Atftpd Containers (Offline)] **********************
skipping: [localhost] => (item={u'tar_file': u'mongo.tar', u'image': u'mongo', u'name': u'hanlon-mongo'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_hanlon.tar', u'image': u'cscdock/hanlon:2.5.0', u'name': u'hanlon-server'})
skipping: [localhost] => (item={u'tar_file': u'cscdock_atftpd.tar', u'image': u'cscdock/atftpd', u'name': u'hanlon-atftpd'})

TASK [Start Mongo Container] ***************************************************
changed: [localhost]

TASK [Remove hanlon client config file] ****************************************
ok: [localhost]

TASK [Start Hanlon Server Container] *******************************************
changed: [localhost]

TASK [Wait for Hanlon Server to start] *****************************************
FAILED - RETRYING: TASK: Wait for Hanlon Server to start (2 retries left). Result was: {'invocation': {'module_name': u'uri', u'module_args': {u'directory_mode': None, u'force': None, u'remote_src': None, u'follow_redirects': u'safe', u'follow': False, u'owner': None, u'body_format': u'raw', u'group': None, u'serole': None, u'content': None, u'setype': None, u'status_code': [200], u'return_content': True, u'method': u'GET', u'body': None, u'dest': None, u'selevel': None, u'force_basic_auth': False, u'removes': None, u'user': None, u'regexp': None, u'password': None, u'src': None, u'url': u'http://10.0.10.4:8026/hanlon/api/v1/config/ipxe', u'backup': None, u'seuser': None, u'creates': None, u'delimiter': None, u'mode': None, u'timeout': 30, u'validate_certs': True}}, u'msg': u'Socket error: [Errno 111] Connection refused to http://10.0.10.4:8026/hanlon/api/v1/config/ipxe', u'failed': True}
ok: [localhost]

TASK [Start TFTP Server Container] *********************************************
changed: [localhost]

PLAY [Configure deployment node for site discovery] ****************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [dhcp-server : install dhcp server package] *******************************
ok: [localhost]

TASK [dhcp-server : Configure dhcpd.conf] **************************************
changed: [localhost]

TASK [dhcp-server : Configure ipxe.conf] ***************************************
changed: [localhost]

TASK [dhcp-server : Copy ipxe-option-space.conf] *******************************
changed: [localhost]

TASK [dhcp-server : enable dhcpd service] **************************************
changed: [localhost]

TASK [Check for local copy of Hanlon Microkernel] ******************************
ok: [localhost]

TASK [Download Hanlon Microkernel (Online)] ************************************
changed: [localhost]

TASK [Copy Hanlon Microkernel to /opt/hanlon/image (Offline)] ******************
skipping: [localhost]

TASK [Add a Microkernel Image to Hanlon] ***************************************
changed: [localhost]

TASK [Add a Discover Only Model to Hanlon] *************************************
changed: [localhost]

TASK [Add a Discover Only Policy to Hanlon] ************************************
changed: [localhost]

RUNNING HANDLER [dhcp-server : restart dhcpd] **********************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=51   changed=35   unreachable=0    failed=0

[root@rhel72 ~]#
```